### PR TITLE
Continue loop if failed to pollRefs

### DIFF
--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -235,6 +235,7 @@ func (c *Client) pollProject(p Project) {
 		refs, err := c.pollRefs(gp.ID, p.Refs)
 		if err != nil {
 			log.Warnf("Could not fetch refs for project '%s'", p.Name)
+			continue
 		}
 
 		if len(refs) > 0 {


### PR DESCRIPTION
I get this error sometimes which causes docker instance to crash:

```
time="2019-10-04T06:54:17Z" level=info msg="Polling refs for project : agilob/..."
time="2019-10-04T06:54:34Z" level=info msg="Fetching project : agilob/..."
time="2019-10-04T06:54:34Z" level=info msg="Polling refs for project : agilob/
time="2019-10-04T06:55:29Z" level=error msg="ListProjectPipelines: Get https://gitlab.com/api/v4/projects/...../pipelines?ref=master: read tcp 172.24.0.5:46362->35.231.145.151:443: read: connection reset by peer"
panic: runtime error: index out of range

goroutine 89 [running]:
github.com/mvisonneau/gitlab-ci-pipelines-exporter/cmd.(*Client).pollProjectRef(0xc00000e280, 0xc000236000, 0xc0004a80b8, 0x6)
        /build/cmd/gitlab.go:267 +0xf39
```

In case of `refs, err := c.pollRefs(gp.ID, p.Refs)` failing with err value, `refs` isn't allocated(?) and causes panic n lines below. This PR should fix the issue I'm having.  

I'll look at #21 in the next days too.

Personally I think this error and error handler above shouldn't continue the loop but cause sleep which is at the end of the loop. Moving `time.Sleep` at the top would create less network traffic in case of failing DNS or 3rd party api being unavailable. What do you think about it?