### PR TITLE
Dont crash when DNS lookup fails

### DIFF
--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -276,7 +276,7 @@ func (c *Client) pollProjectRef(gp *gitlab.Project, ref string) {
 		}
 
 		if len(pipelines) == 0 {
-			log.Debug("Could not find any pipeline for %s:%s", gp.PathWithNamespace, ref)
+			log.Debugf("Could not find any pipeline for %s:%s", gp.PathWithNamespace, ref)
 		} else if lastPipeline == nil || lastPipeline.ID != pipelines[0].ID || lastPipeline.Status != pipelines[0].Status {
 			if lastPipeline != nil {
 				runCount.WithLabelValues(gp.PathWithNamespace, ref).Inc()


### PR DESCRIPTION
to get list of pipelines

minor code cleanup to decrease indentation and fix index out of range bug #21

decreased log level for message `log.Debug("Could not find any pipeline for ` from warn to debug as it's seems to me that many project won't have any available running pipeline in last days, especially on side-projects or during long holidays. Happy to revert this if you disagree.