### PR TITLE
load gitlab.token from env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,7 @@ and this project adheres to [0ver](https://0ver.org).
 ### Added
 
 - Added global rate limit capability to avoid hammering GitLab API endpoints
-
-### Added
-
-- Load gitlab token from the environment (`GITLAB_TOKEN`) when `gitlab.token` is not configured
+- Added `--token, -t` flag. Can be use to specify the gitlab token as flag or env var.
 
 ## [0.2.10] - 2019-12-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [0ver](https://0ver.org).
 ### Added
 
 - Added global rate limit capability to avoid hammering GitLab API endpoints
-- Added `--token, -t` flag. Can be use to specify the gitlab token as flag or env var.
+- Added `--gitlab-token` flag. Can be use to specify the gitlab token as flag or env var.
 
 ## [0.2.10] - 2019-12-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [0ver](https://0ver.org).
 
 - Added global rate limit capability to avoid hammering GitLab API endpoints
 
+### Added
+
+- Load gitlab token from the environment (`GITLAB_TOKEN`) when `gitlab.token` is not configured
+
 ## [0.2.10] - 2019-12-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you are solely interested into trying it out, have a look into the [example/]
 # pipelines informations
 gitlab:
   url: https://gitlab.example.com
-  token: xrN14n9-ywvAFxxxxxx                         # Gitlab access token. Omit this field to use "GITLAB_TOKEN" from the environment.
+  token: xrN14n9-ywvAFxxxxxx                         # Gitlab access token. You can omit this field when --token or $GCPE_TOKEN are set
   # health_url: https://gitlab.example.com/-/health  # Alternative URL for determining health of GitLab API (readiness probe)
   # skip_tls_verify: false                           # disable TLS verification
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ GLOBAL OPTIONS:
    --log-format format            log format (json,text) (default: "text") [$GCPE_LOG_FORMAT]
    --listen-address address:port  listen-address address:port (default: ":8080") [$GCPE_LISTEN_ADDRESS]
    --config file                  config file (default: "~/.gitlab-ci-pipelines-exporter.yml") [$GCPE_CONFIG]
+   --gitlab-token token           GitLab access token. Can be use to override the gitlab token in config file [$GCPE_GITLAB_TOKEN]
    --help, -h                     show help
    --version, -v                  print the version
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you are solely interested into trying it out, have a look into the [example/]
 # pipelines informations
 gitlab:
   url: https://gitlab.example.com
-  token: xrN14n9-ywvAFxxxxxx
+  token: xrN14n9-ywvAFxxxxxx                         # Gitlab access token. Omit this field to use "GITLAB_TOKEN" from the environment.
   # health_url: https://gitlab.example.com/-/health  # Alternative URL for determining health of GitLab API (readiness probe)
   # skip_tls_verify: false                           # disable TLS verification
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -40,6 +40,11 @@ func Init(version *string) (app *cli.App) {
 			Usage:  "config `file`",
 			Value:  "~/.gitlab-ci-pipelines-exporter.yml",
 		},
+		cli.StringFlag{
+			Name:   "token, t",
+			EnvVar: "GCPE_TOKEN",
+			Usage:  "GitLab access `token`. Can be use to override the gitlab token in config file",
+		},
 	}
 
 	app.Action = cmd.Run

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -41,8 +41,8 @@ func Init(version *string) (app *cli.App) {
 			Value:  "~/.gitlab-ci-pipelines-exporter.yml",
 		},
 		cli.StringFlag{
-			Name:   "token, t",
-			EnvVar: "GCPE_TOKEN",
+			Name:   "gitlab-token",
+			EnvVar: "GCPE_GITLAB_TOKEN",
 			Usage:  "GitLab access `token`. Can be use to override the gitlab token in config file",
 		},
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v3"
 )
@@ -105,6 +106,11 @@ func (cfg *Config) Parse(path string) error {
 	if cfg.Gitlab.HealthURL == "" {
 		cfg.Gitlab.HealthURL = fmt.Sprintf("%s/users/sign_in", cfg.Gitlab.URL)
 	}
+
+	if cfg.Gitlab.Token == "" {
+		cfg.Gitlab.Token = os.Getenv("GITLAB_TOKEN")
+	}
+
 
 	return nil
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 
+	"github.com/urfave/cli"
 	"gopkg.in/yaml.v3"
 )
 
@@ -107,9 +107,12 @@ func (cfg *Config) Parse(path string) error {
 		cfg.Gitlab.HealthURL = fmt.Sprintf("%s/users/sign_in", cfg.Gitlab.URL)
 	}
 
-	if cfg.Gitlab.Token == "" {
-		cfg.Gitlab.Token = os.Getenv("GITLAB_TOKEN")
-	}
-
 	return nil
+}
+
+func (cfg *Config) MergeWithContext(ctx *cli.Context) {
+	token := ctx.GlobalString("token")
+	if len(token) != 0 {
+		cfg.Gitlab.Token = token
+	}
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -111,6 +111,5 @@ func (cfg *Config) Parse(path string) error {
 		cfg.Gitlab.Token = os.Getenv("GITLAB_TOKEN")
 	}
 
-
 	return nil
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -208,3 +208,35 @@ projects:
 		t.Fatalf("Diff of expected/got config :\n %v", cmp.Diff(*cfg, expectedCfg))
 	}
 }
+
+func TestParseEnvironmentVariables(t *testing.T) {
+	f, err := ioutil.TempFile("/tmp", "test-")
+	if err != nil {
+		t.Fatal("Could not create temporary test files")
+	}
+	defer os.Remove(f.Name())
+
+	// Valid minimal configuration
+	f.WriteString(`
+---
+projects:
+  - name: foo/bar
+`)
+
+	expectedGitlabToken := "foo-bar"
+
+	os.Setenv("GITLAB_TOKEN", expectedGitlabToken)
+	defer os.Setenv("GITLAB_TOKEN", "")
+
+	// Reset config var before parsing
+	cfg = &Config{}
+
+	err = cfg.Parse(f.Name())
+	if err != nil {
+		t.Fatalf("Did not expect an error, got %s", err.Error())
+	}
+
+	if !cmp.Equal(cfg.Gitlab.Token, expectedGitlabToken) {
+		t.Fatalf("Diff of expected/got gitlab token :\n %v", cmp.Diff(cfg.Gitlab.Token, expectedGitlabToken))
+	}
+}

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -97,10 +97,12 @@ func Run(ctx *cli.Context) error {
 		return exit(err, 1)
 	}
 
-	// Parse config file
+	// Initialize config
 	if err := cfg.Parse(ctx.GlobalString("config")); err != nil {
 		return exit(err, 1)
 	}
+
+	cfg.MergeWithContext(ctx)
 
 	log.Infof("Starting exporter")
 	log.Infof("Configured GitLab endpoint : %s", cfg.Gitlab.URL)

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -120,7 +120,7 @@ func Run(ctx *cli.Context) error {
 		Client:      gitlab.NewClient(&http.Client{Transport: httpTransport}, cfg.Gitlab.Token),
 		RateLimiter: ratelimit.New(cfg.MaximumGitLabAPIRequestsPerSecond),
 	}
-	c.SetBaseURL(cfg.Gitlab.URL)
+	_ = c.SetBaseURL(cfg.Gitlab.URL)
 
 	go c.pollProjects()
 


### PR DESCRIPTION
# Description

Currently, you cannot add your yml configuration to git without publishing your gitlab access token. This PR allows you to omit the token from your yml and set it through an environment variable before app start.

Docker example:
```
~$ docker run -d \
   --name gitlab-ci-pipelines-exporter \
   -v $(pwd)/config.yml:/etc/config.yml \
   -p 8080:8080 \
  --env GITLAB_TOKEN=<YOUR_TOKEN>
   mvisonneau/gitlab-ci-pipelines-exporter:latest \
   --config /etc/config.yml
```

# Checklist
- [x] Tests
- [x] Docs
- [x] Changelog