### PR TITLE
fix --gitlab-token and improve docs/helm-chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [0ver](https://0ver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- Fix `--gitlab-token` and improve docs/chart
+
 ## [0.2.11] - 2019-02-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you are solely interested into trying it out, have a look into the [example/]
 # pipelines informations
 gitlab:
   url: https://gitlab.example.com
-  token: xrN14n9-ywvAFxxxxxx                         # Gitlab access token. You can omit this field when --token or $GCPE_TOKEN are set
+  token: xrN14n9-ywvAFxxxxxx                         # Gitlab access token. You can omit this field when --gitlab-token or $GCPE_GITLAB_TOKEN  are set
   # health_url: https://gitlab.example.com/-/health  # Alternative URL for determining health of GitLab API (readiness probe)
   # skip_tls_verify: false                           # disable TLS verification
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -101,3 +101,5 @@ envVariables: []
   #   value: json
   # - name: GCPE_LOG_LEVEL
   #   value: debug
+  # - name: GCPE_GITLAB_TOKEN
+  #   value: "<your-gitlab-token>"

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -111,7 +111,7 @@ func (cfg *Config) Parse(path string) error {
 }
 
 func (cfg *Config) MergeWithContext(ctx *cli.Context) {
-	token := ctx.GlobalString("token")
+	token := ctx.GlobalString("gitlab-token")
 	if len(token) != 0 {
 		cfg.Gitlab.Token = token
 	}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -243,7 +243,7 @@ projects:
 	}
 
 	set := flag.NewFlagSet("", 0)
-	set.String("token", expectedCtxToken, "")
+	set.String("gitlab-token", expectedCtxToken, "")
 
 	ctx := cli.NewContext(nil, set, nil)
 	cfg.MergeWithContext(ctx)


### PR DESCRIPTION
Fix `gitlab-token` CLI/ENV injection and improve doc/helm-chart. See #50 

@zhenwenc
I dont have time to test this. Can you help here ?