### PR TITLE
Add option to override default behaviour around archived projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 .gitlab-ci-pipelines-exporter.yml
 **/.DS_Store
 gitlab-ci-pipelines-exporter
+coverage.out

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ wildcards:
       include_subgroups: true # optional (default: false)
     refs: "^master|1.0$"
     search: 'bar' # optional (defaults to '')
+    archived: true # optional (default: false)
 
   # Fetch projects belonging to a specific user
   - owner:
@@ -68,10 +69,12 @@ wildcards:
       kind: user
     refs: ".*"
     search: 'bar' # optional (defaults to '')
+    archived: true # optional (default: false)
 
   # Search for projects globally
   - refs: ".*"
     search: 'baz' # optional (defaults to '')
+    archived: true # optional (default: false)
 EOF
 
 # If you have docker installed, it is as easy as :

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -43,7 +43,8 @@ type Wildcard struct {
 		Kind             string
 		IncludeSubgroups bool `yaml:"include_subgroups"`
 	}
-	Refs string
+	Archived bool `yaml:"archived"`
+	Refs     string
 }
 
 // Default values

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -73,6 +73,7 @@ wildcards:
       kind: group
     refs: "^master|1.0$"
     search: 'bar'
+    archived: true
 `)
 
 	// Reset config var before parsing
@@ -122,7 +123,8 @@ wildcards:
 					Name: "foo",
 					Kind: "group",
 				},
-				Refs: "^master|1.0$",
+				Refs:     "^master|1.0$",
+				Archived: true,
 			},
 		},
 	}

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -43,7 +43,6 @@ func (c *Client) listProjects(w *Wildcard) ([]Project, error) {
 
 	projects := []Project{}
 	trueVal := true
-	falseVal := false
 	listOptions := gitlab.ListOptions{
 		PerPage: 20,
 		Page:    1,
@@ -60,7 +59,7 @@ func (c *Client) listProjects(w *Wildcard) ([]Project, error) {
 			gps, resp, err = c.Projects.ListUserProjects(
 				w.Owner.Name,
 				&gitlab.ListProjectsOptions{
-					Archived:    &falseVal,
+					Archived:    &w.Archived,
 					ListOptions: listOptions,
 					Search:      &w.Search,
 					Simple:      &trueVal,
@@ -70,7 +69,7 @@ func (c *Client) listProjects(w *Wildcard) ([]Project, error) {
 			gps, resp, err = c.Groups.ListGroupProjects(
 				w.Owner.Name,
 				&gitlab.ListGroupProjectsOptions{
-					Archived:         &falseVal,
+					Archived:         &w.Archived,
 					IncludeSubgroups: &w.Owner.IncludeSubgroups,
 					ListOptions:      listOptions,
 					Search:           &w.Search,
@@ -81,7 +80,7 @@ func (c *Client) listProjects(w *Wildcard) ([]Project, error) {
 			gps, resp, err = c.Projects.ListProjects(
 				&gitlab.ListProjectsOptions{
 					ListOptions: listOptions,
-					Archived:    &falseVal,
+					Archived:    &w.Archived,
 					Simple:      &trueVal,
 					Search:      &w.Search,
 				},

--- a/cmd/gitlab_test.go
+++ b/cmd/gitlab_test.go
@@ -78,7 +78,8 @@ func TestListUserProjects(t *testing.T) {
 			Kind:             "user",
 			IncludeSubgroups: false,
 		},
-		Refs: "^master|1.0$",
+		Archived: false,
+		Refs:     "^master|1.0$",
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s/projects", w.Owner.Name),
@@ -107,7 +108,8 @@ func TestListGroupProjects(t *testing.T) {
 			Kind:             "group",
 			IncludeSubgroups: false,
 		},
-		Refs: "^master|1.0$",
+		Archived: false,
+		Refs:     "^master|1.0$",
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/api/v4/groups/%s/projects", w.Owner.Name),
@@ -136,7 +138,8 @@ func TestListProjects(t *testing.T) {
 			Kind:             "",
 			IncludeSubgroups: false,
 		},
-		Refs: "",
+		Archived: false,
+		Refs:     "",
 	}
 
 	mux.HandleFunc("/api/v4/projects",
@@ -164,7 +167,8 @@ func TestListProjectsAPIError(t *testing.T) {
 			Name: "foo",
 			Kind: "user",
 		},
-		Refs: "",
+		Archived: false,
+		Refs:     "",
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/api/v4/users/%s/projects", w.Owner.Name),


### PR DESCRIPTION
Hi, I've been using this exporter for a few weeks, and there are a couple of things blocking us from going live with it:

* Ability to skip archived projects (we normally leave them in thier original place in our gitlab group hierarchy when we archive them)
* Addition of more labels (getting some additional context of the projects)

This PR should resolve that initial requirement, and I'll try and come back for that second one later.