### PR TITLE
Add service labels in helm template

### DIFF
--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ template "exporter.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{ toYaml .Values.service.labels | indent 4 }}
   name: {{ template "exporter.fullname" . }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}


### PR DESCRIPTION
Add missing substitution for service labels in the helm chart service template.