### PR TITLE
WIP: First draft, hardcoded stats

### DIFF
--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -73,6 +73,14 @@ var (
 		},
 		[]string{"project", "topics", "ref"},
 	)
+
+	commitCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gitlab_project_commit_count",
+			Help: "GitLab project commit count in default ref",
+		},
+		[]string{"project", "topics", "ref"},
+	)
 )
 
 func init() {
@@ -83,6 +91,7 @@ func init() {
 	prometheus.MustRegister(lastRunStatus)
 	prometheus.MustRegister(runCount)
 	prometheus.MustRegister(timeSinceLastRun)
+	prometheus.MustRegister(commitCount)
 }
 
 // Run launches the exporter

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -34,7 +34,13 @@ func refExists(refs []string, r string) bool {
 
 func (c *Client) getProject(name string) (*gitlab.Project, error) {
 	c.rateLimit()
-	p, _, err := c.Projects.GetProject(name, &gitlab.GetProjectOptions{})
+	trueVal := true
+
+	p, _, err := c.Projects.GetProject(name, &gitlab.GetProjectOptions{Statistics: &trueVal})
+	log.Infof("RFG: '%s' project has %d commits", p.PathWithNamespace, p.Statistics.CommitCount)
+	topics := strings.Join(p.TagList[:], ",")
+	commitCount.WithLabelValues(p.PathWithNamespace, topics, p.DefaultBranch).Set(float64(p.Statistics.CommitCount))
+
 	return p, err
 }
 


### PR DESCRIPTION
This is a rough draft of my propsoal for https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/issues/51 - changes I would like to make are:

- Make project statistics optional, defaulting to false for backward compatibility
- Add a few other statistics
- Use a naming like `gitlab_project_statistics_commit_count`

Also, do you think I should have used a counter for the commits?  I used a gauge to cover the case where someone force pushes a ref with less commits (squashing, etc.).