### PR TITLE
Add helm apiVersion to chart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,3 +2,4 @@ name: gitlab-ci-pipelines-exporter
 version: 0.2.13
 appVersion: 0.2.13
 description: Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
+apiVersion: v2


### PR DESCRIPTION
Avoids linting error because apiVersion is mandatory:

    $ helm lint ./chart
    ==> Linting ./chart
    [ERROR] Chart.yaml: apiVersion is required. The value must be either "v1" or "v2"
    [INFO] Chart.yaml: icon is recommended
    
    Error: 1 chart(s) linted, 1 chart(s) failed`