### PR TITLE
Add pipeline status “manual”

### DIFF
--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -311,7 +311,7 @@ func (c *Client) outputPipelineStatusMetric(status string, sparseMetrics bool, l
 	outputStatusMetric(
 		lastRunStatus,
 		labels,
-		[]string{"running", "pending", "success", "failed", "canceled", "skipped"},
+		[]string{"running", "pending", "success", "failed", "canceled", "skipped", "manual"},
 		status,
 		sparseMetrics,
 	)


### PR DESCRIPTION
For whatever reason that status isn’t documented but it’s returned by the API. Moreover it’s possible to filter pipelines by that status. So I assume that it’s just a mistake in the GitLab documentation.

<img width="461" alt="Screenshot 2020-04-09 at 10 40 33" src="https://user-images.githubusercontent.com/172760/78876302-6c86cc80-7a4f-11ea-98e1-948c9f4c5a5d.png">
