### PR TITLE
concurrent projects polling; syntax fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [0ver](https://0ver.org).
 
 ## [Unreleased]
 
+## [0.2.15] - 2020-04-??
+
+### Added
+
+- Configuration for OpenMetrics Encoding in metrics HTTP endpoint: `prometheus_openmetrics_encoding` can be set `true` or `false` (default)
+- Worker pool for projects polling: set `maximum_projects_poller_workers` with an integer value to control parallelism (defaults to `runtime.GOMAXPROCS(0)`)  
+
+### Changed
+
+- Projects polling from GitLab API is done in parallel using `maximum_projects_poller_workers` pollers and concurrently fetching refs and projects
+
 ## [0.2.14] - 2019-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ projects_polling_interval_seconds: 1800 # only used for wildcards
 refs_polling_interval_seconds: 300
 pipelines_polling_interval_seconds: 60
 
-# When no pipeline exists for a given ref, the exporter will exponentially backoff up to this value
-pipelines_max_polling_interval_seconds: 1800
-
 # Whether to attempt retrieving refs from pipelines when the exporter starts (default: false)
 on_init_fetch_refs_from_pipelines: false
 # Maximum number of pipelines to analyze per project to search for refs on init (default: 100)

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -81,7 +81,6 @@ config: {}
   # projects_polling_interval_seconds: 300            # Interval in seconds at which to poll projects from wildcards
   # refs_polling_interval_seconds: 5                  # Interval in seconds to fetch refs from projects
   # pipelines_polling_interval_seconds: 10            # Interval in seconds to get new pipelines from refs (exponentially backing of to maximum value)
-  # pipelines_max_polling_interval_seconds: 1800      # Maximum interval in seconds to fetch new pipelines from refs 
   # projects:
   #   - name: foo/project
   #     refs: "^master|develop|1.0$"

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -22,7 +22,6 @@ type Config struct {
 	ProjectsPollingIntervalSeconds         int        `yaml:"projects_polling_interval_seconds"`             // Interval in seconds at which to poll projects from wildcards
 	RefsPollingIntervalSeconds             int        `yaml:"refs_polling_interval_seconds"`                 // Interval in seconds to fetch refs from projects
 	PipelinesPollingIntervalSeconds        int        `yaml:"pipelines_polling_interval_seconds"`            // Interval in seconds to get new pipelines from refs (exponentially backing of to maximum value)
-	PipelinesMaxPollingIntervalSeconds     int        `yaml:"pipelines_max_polling_interval_seconds"`        // Maximum interval in seconds to fetch new pipelines from refs
 	FetchPipelineJobMetrics                bool       `yaml:"fetch_pipeline_job_metrics"`                    // Whether to attempt to retrieve job metrics from polled pipelines
 	OutputSparseStatusMetrics              bool       `yaml:"output_sparse_status_metrics"`                  // Whether to report all pipeline / job statuses, or only report the one from the last job.
 	OnInitFetchRefsFromPipelines           bool       `yaml:"on_init_fetch_refs_from_pipelines"`             // Whether to attempt retrieving refs from pipelines when the exporter starts
@@ -116,10 +115,6 @@ func (cfg *Config) Parse(path string) error {
 
 	if cfg.PipelinesPollingIntervalSeconds == 0 {
 		cfg.PipelinesPollingIntervalSeconds = defaultPipelinesPollingIntervalSeconds
-	}
-
-	if cfg.PipelinesMaxPollingIntervalSeconds == 0 {
-		cfg.PipelinesMaxPollingIntervalSeconds = defaultPipelinesMaxPollingIntervalSeconds
 	}
 
 	if cfg.OnInitFetchRefsFromPipelinesDepthLimit == 0 {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -65,7 +65,7 @@ const (
 	defaultProjectsPollingIntervalSeconds         = 1800
 	defaultRefsPollingIntervalSeconds             = 300
 
-	errNoProjectsOrWildacrdConfigured = "you need to configure at least one project/wildcard to poll, none given"
+	errNoProjectsOrWildcardConfigured = "you need to configure at least one project/wildcard to poll, none given"
 	errConfigFileNotFound             = "couldn't open config file : %v"
 )
 
@@ -102,7 +102,7 @@ func (cfg *Config) Parse(path string) error {
 	}
 
 	if len(cfg.Projects) < 1 && len(cfg.Wildcards) < 1 {
-		return fmt.Errorf(errNoProjectsOrWildacrdConfigured)
+		return fmt.Errorf(errNoProjectsOrWildcardConfigured)
 	}
 
 	// Defining defaults

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -65,7 +65,7 @@ const (
 	defaultRefsPollingIntervalSeconds             = 300
 )
 
-var cfg *Config
+var cfg = &Config{}
 
 // ShouldFetchPipelineJobMetrics returns true if pipeline job statistics should be fetched
 func (p *Project) ShouldFetchPipelineJobMetrics(cfg *Config) bool {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -57,7 +57,6 @@ maximum_gitlab_api_requests_per_second: 1
 projects_polling_interval_seconds: 2
 refs_polling_interval_seconds: 3
 pipelines_polling_interval_seconds: 4
-pipelines_max_polling_interval_seconds: 5
 on_init_fetch_refs_from_pipelines: true
 on_init_fetch_refs_from_pipelines_depth_limit: 1337
 default_refs: "^dev$"
@@ -98,7 +97,6 @@ wildcards:
 		ProjectsPollingIntervalSeconds:         2,
 		RefsPollingIntervalSeconds:             3,
 		PipelinesPollingIntervalSeconds:        4,
-		PipelinesMaxPollingIntervalSeconds:     5,
 		OnInitFetchRefsFromPipelines:           true,
 		OnInitFetchRefsFromPipelinesDepthLimit: 1337,
 		DefaultRefsRegexp:                      "^dev$",
@@ -167,7 +165,6 @@ projects:
 		ProjectsPollingIntervalSeconds:         defaultProjectsPollingIntervalSeconds,
 		RefsPollingIntervalSeconds:             defaultRefsPollingIntervalSeconds,
 		PipelinesPollingIntervalSeconds:        defaultPipelinesPollingIntervalSeconds,
-		PipelinesMaxPollingIntervalSeconds:     defaultPipelinesMaxPollingIntervalSeconds,
 		OnInitFetchRefsFromPipelines:           false,
 		OnInitFetchRefsFromPipelinesDepthLimit: defaultOnInitFetchRefsFromPipelinesDepthLimit,
 		DefaultRefsRegexp:                      "",

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -208,7 +208,7 @@ func Run(ctx *cli.Context) error {
 	mux.HandleFunc("/health/ready", health.ReadyEndpoint)
 	mux.Handle("/metrics", promhttp.HandlerFor(metrics, promhttp.HandlerOpts{
 		Registry:          metrics,
-		EnableOpenMetrics: true,
+		EnableOpenMetrics: cfg.PrometheusOpenmetricsEncoding,
 	}))
 
 	srv := &http.Server{

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -140,7 +140,7 @@ func newMetricsRegistry() *prometheus.Registry {
 // Run launches the exporter
 func Run(ctx *cli.Context) error {
 	// register metrics
-	metrics :=  newMetricsRegistry()
+	metrics := newMetricsRegistry()
 
 	// Configure logger
 	lc := &logger.Config{
@@ -207,7 +207,7 @@ func Run(ctx *cli.Context) error {
 	mux.HandleFunc("/health/live", health.LiveEndpoint)
 	mux.HandleFunc("/health/ready", health.ReadyEndpoint)
 	mux.Handle("/metrics", promhttp.HandlerFor(metrics, promhttp.HandlerOpts{
-		Registry:metrics,
+		Registry:          metrics,
 		EnableOpenMetrics: true,
 	}))
 
@@ -224,7 +224,7 @@ func Run(ctx *cli.Context) error {
 	log.Infof("Started listening onto %s", ctx.GlobalString("listen-address"))
 
 	<-onShutdown
-	stopPolling<-true
+	stopPolling <- true
 	log.Print("Stopped!")
 
 	ctxt, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -189,9 +189,9 @@ func Run(ctx *cli.Context) error {
 
 	// Graceful shutdowns
 	onShutdown := make(chan os.Signal, 1)
-	stopPolling := make(chan bool)
-	signal.Notify(onShutdown, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(onShutdown, syscall.SIGINT, syscall.SIGTERM, syscall.SIGABRT)
 
+	stopPolling := make(chan bool)
 	c.pollProjects(stopPolling)
 
 	// Configure liveness and readiness probes

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -119,23 +119,29 @@ var (
 	)
 )
 
-func init() {
-	cfg = &Config{}
-	prometheus.MustRegister(coverage)
-	prometheus.MustRegister(lastRunDuration)
-	prometheus.MustRegister(lastRunID)
-	prometheus.MustRegister(lastRunStatus)
-	prometheus.MustRegister(runCount)
-	prometheus.MustRegister(timeSinceLastRun)
-	prometheus.MustRegister(lastRunJobDuration)
-	prometheus.MustRegister(lastRunJobStatus)
-	prometheus.MustRegister(jobRunCount)
-	prometheus.MustRegister(timeSinceLastJobRun)
-	prometheus.MustRegister(lastRunJobArtifactSize)
+func newMetricsRegistry() *prometheus.Registry {
+	registry := prometheus.NewRegistry()
+
+	registry.MustRegister(coverage)
+	registry.MustRegister(lastRunDuration)
+	registry.MustRegister(lastRunID)
+	registry.MustRegister(lastRunStatus)
+	registry.MustRegister(runCount)
+	registry.MustRegister(timeSinceLastRun)
+	registry.MustRegister(lastRunJobDuration)
+	registry.MustRegister(lastRunJobStatus)
+	registry.MustRegister(jobRunCount)
+	registry.MustRegister(timeSinceLastJobRun)
+	registry.MustRegister(lastRunJobArtifactSize)
+
+	return registry
 }
 
 // Run launches the exporter
 func Run(ctx *cli.Context) error {
+	// register metrics
+	metrics :=  newMetricsRegistry()
+
 	// Configure logger
 	lc := &logger.Config{
 		Level:  ctx.GlobalString("log-level"),
@@ -179,10 +185,14 @@ func Run(ctx *cli.Context) error {
 		Client:      gc,
 		RateLimiter: ratelimit.New(cfg.MaximumGitLabAPIRequestsPerSecond),
 	}
-
 	c.UserAgent = userAgent
 
-	go c.pollProjects()
+	// Graceful shutdowns
+	onShutdown := make(chan os.Signal, 1)
+	stopPolling := make(chan bool)
+	signal.Notify(onShutdown, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	c.pollProjects(stopPolling)
 
 	// Configure liveness and readiness probes
 	health := healthcheck.NewHandler()
@@ -192,15 +202,14 @@ func Run(ctx *cli.Context) error {
 		log.Warn("TLS verification has been disabled. Readiness checks won't be operated.")
 	}
 
-	// Graceful shutdowns
-	done := make(chan os.Signal, 1)
-	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
-
 	// Expose the registered metrics via HTTP
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health/live", health.LiveEndpoint)
 	mux.HandleFunc("/health/ready", health.ReadyEndpoint)
-	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/metrics", promhttp.HandlerFor(metrics, promhttp.HandlerOpts{
+		Registry:metrics,
+		EnableOpenMetrics: true,
+	}))
 
 	srv := &http.Server{
 		Addr:    ctx.GlobalString("listen-address"),
@@ -214,7 +223,8 @@ func Run(ctx *cli.Context) error {
 	}()
 	log.Infof("Started listening onto %s", ctx.GlobalString("listen-address"))
 
-	<-done
+	<-onShutdown
+	stopPolling<-true
 	log.Print("Stopped!")
 
 	ctxt, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/cmd/exporter_test.go
+++ b/cmd/exporter_test.go
@@ -34,5 +34,5 @@ func TestRunInvalidConfigFile(t *testing.T) {
 	set.String("log-format", "json", "")
 	set.String("config", "path_does_not_exist", "")
 	err := Run(cli.NewContext(nil, set, nil))
-	assert.Equal(t, true, strings.HasPrefix(err.Error(), "Couldn't open config file :"))
+	assert.Equal(t, true, strings.HasPrefix(err.Error(), "couldn't open config file :"))
 }

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -3,12 +3,12 @@ package cmd
 import (
 	"fmt"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/jpillora/backoff"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/xanzy/go-gitlab"
 
@@ -42,7 +42,7 @@ func (c *Client) getProject(name string) (*gitlab.Project, error) {
 func (c *Client) listProjects(w *Wildcard) ([]Project, error) {
 	log.Debugf("Listing all projects using search pattern : '%s' with owner '%s' (%s)", w.Search, w.Owner.Name, w.Owner.Kind)
 
-	projects := []Project{}
+	var projects []Project
 	trueVal := true
 	listOptions := gitlab.ListOptions{
 		PerPage: 20,
@@ -89,7 +89,7 @@ func (c *Client) listProjects(w *Wildcard) ([]Project, error) {
 		}
 
 		if err != nil {
-			return projects, fmt.Errorf("Unable to list projects with search pattern '%s' from the GitLab API : %v", w.Search, err.Error())
+			return projects, fmt.Errorf("unable to list projects with search pattern '%s' from the GitLab API : %v", w.Search, err.Error())
 		}
 
 		// Copy relevant settings from wildcard into created project
@@ -116,24 +116,7 @@ func (c *Client) listProjects(w *Wildcard) ([]Project, error) {
 	return projects, nil
 }
 
-func (c *Client) pollProjectsFromWildcards() {
-	for _, w := range cfg.Wildcards {
-		foundProjects, err := c.listProjects(&w)
-		if err != nil {
-			log.Error(err.Error())
-		} else {
-			for _, p := range foundProjects {
-				if !projectExists(p) {
-					log.Infof("Found project : %s", p.Name)
-					go c.pollProject(p)
-					cfg.Projects = append(cfg.Projects, p)
-				}
-			}
-		}
-	}
-}
-
-func (c *Client) pollRefs(projectID int, refsRegexp string) (refs []string, err error) {
+func (c *Client) branchesAndTagsFor(projectID int, refsRegexp string) (refs []string, err error) {
 	if len(refsRegexp) == 0 {
 		if len(cfg.DefaultRefsRegexp) > 0 {
 			refsRegexp = cfg.DefaultRefsRegexp
@@ -144,7 +127,7 @@ func (c *Client) pollRefs(projectID int, refsRegexp string) (refs []string, err 
 
 	re := regexp.MustCompile(refsRegexp)
 
-	branches, err := c.pollBranchNames(projectID)
+	branches, err := c.branchNamesFor(projectID)
 	if err != nil {
 		return
 	}
@@ -155,7 +138,7 @@ func (c *Client) pollRefs(projectID int, refsRegexp string) (refs []string, err 
 		}
 	}
 
-	tags, err := c.pollTagNames(projectID)
+	tags, err := c.tagNamesFor(projectID)
 	if err != nil {
 		return
 	}
@@ -169,7 +152,7 @@ func (c *Client) pollRefs(projectID int, refsRegexp string) (refs []string, err 
 	return
 }
 
-func (c *Client) pollBranchNames(projectID int) ([]*string, error) {
+func (c *Client) branchNamesFor(projectID int) ([]*string, error) {
 	var names []*string
 
 	options := &gitlab.ListBranchesOptions{
@@ -200,7 +183,7 @@ func (c *Client) pollBranchNames(projectID int) ([]*string, error) {
 	return names, nil
 }
 
-func (c *Client) pollTagNames(projectID int) ([]*string, error) {
+func (c *Client) tagNamesFor(projectID int) ([]*string, error) {
 	var names []*string
 
 	options := &gitlab.ListTagsOptions{
@@ -231,62 +214,55 @@ func (c *Client) pollTagNames(projectID int) ([]*string, error) {
 	return names, nil
 }
 
-func (c *Client) pollProject(p Project) {
+func (c *Client) pollProject(p Project) error {
 	var polledRefs []string
 	var err error
 
-	for {
-		log.Debugf("Fetching project : %s", p.Name)
-		p.GitlabProject, err = c.getProject(p.Name)
+	log.Debugf("Fetching project : %s", p.Name)
+	p.GitlabProject, err = c.getProject(p.Name)
+	if err != nil {
+		return fmt.Errorf("unable to fetch project '%s' from the GitLab API : %v", p.Name, err.Error())
+	}
+
+	if cfg.OnInitFetchRefsFromPipelines {
+		log.Debugf("Polling project refs %s from most recent %d pipelines (init only)", p.Name, cfg.OnInitFetchRefsFromPipelinesDepthLimit)
+		refs, err := c.pollProjectRefsFromPipelines(p.GitlabProject.ID, cfg.OnInitFetchRefsFromPipelinesDepthLimit)
 		if err != nil {
-			log.Errorf("Unable to fetch project '%s' from the GitLab API : %v", p.Name, err.Error())
-			time.Sleep(time.Duration(cfg.RefsPollingIntervalSeconds) * time.Second)
-			continue
+			return fmt.Errorf("unable to fetch refs from project pipelines %s : %v", p.Name, err.Error())
 		}
 
-		if cfg.OnInitFetchRefsFromPipelines {
-			log.Debugf("Polling project refs %s from most recent %d pipelines (init only)", p.Name, cfg.OnInitFetchRefsFromPipelinesDepthLimit)
-			refs, err := c.pollProjectRefsFromPipelines(p.GitlabProject.ID, cfg.OnInitFetchRefsFromPipelinesDepthLimit)
-			if err != nil {
-				log.Errorf("Unable to fetch refs from project pipelines %s : %v", p.Name, err.Error())
-				time.Sleep(time.Duration(cfg.RefsPollingIntervalSeconds) * time.Second)
+		log.Debugf("Found %d refs from %s pipelines", len(refs), p.Name)
+		for _, r := range refs {
+			log.Infof("Found ref '%s' for project '%s'", r, p.Name)
+			if err := c.pollProjectRef(p, r); err != nil {
+				log.Errorf("Error getting pipeline data on ref '%s' for project '%s'", r, p.Name)
 				continue
 			}
+			polledRefs = append(polledRefs, r)
+		}
+	}
+	log.Debugf("Polling refs for project : %s", p.Name)
 
-			log.Debugf("Found %d refs from %s pipelines", len(refs), p.Name)
-			for _, r := range refs {
+	refs, err := c.branchesAndTagsFor(p.GitlabProject.ID, p.Refs)
+	if err != nil {
+		return fmt.Errorf("error fetching refs for project '%s'", p.Name)
+	}
+
+	if len(refs) > 0 {
+		for _, r := range refs {
+			if !refExists(polledRefs, r) {
 				log.Infof("Found ref '%s' for project '%s'", r, p.Name)
-				go c.pollProjectRef(p, r)
+				if err := c.pollProjectRef(p, r); err != nil {
+					log.Errorf("Error getting pipeline data on ref '%s' for project '%s'", r, p.Name)
+					continue
+				}
 				polledRefs = append(polledRefs, r)
 			}
 		}
-
-		break
 	}
 
-	for {
-		log.Debugf("Polling refs for project : %s", p.Name)
-
-		refs, err := c.pollRefs(p.GitlabProject.ID, p.Refs)
-		if err != nil {
-			log.Warnf("Could not fetch refs for project '%s'", p.Name)
-			continue
-		}
-
-		if len(refs) > 0 {
-			for _, r := range refs {
-				if !refExists(polledRefs, r) {
-					log.Infof("Found ref '%s' for project '%s'", r, p.Name)
-					go c.pollProjectRef(p, r)
-					polledRefs = append(polledRefs, r)
-				}
-			}
-		} else {
-			log.Warnf("No refs found for project '%s'", p.Name)
-		}
-
-		time.Sleep(time.Duration(cfg.RefsPollingIntervalSeconds) * time.Second)
-	}
+	log.Warnf("No refs found for project '%s'", p.Name)
+	return nil
 }
 
 func outputStatusMetric(metric *prometheus.GaugeVec, labels []string, statuses []string, status string, sparseMetrics bool) {
@@ -329,7 +305,7 @@ func (c *Client) outputJobStatusMetric(status string, sparseMetrics bool, labels
 func (c *Client) pollPipelineJobs(p Project, pipelineID int, topics string, ref string) error {
 	var jobs []*gitlab.Job
 	var resp *gitlab.Response
-	var gp *gitlab.Project = p.GitlabProject
+	var gp = p.GitlabProject
 	var err error
 
 	options := &gitlab.ListJobsOptions{
@@ -356,11 +332,11 @@ func (c *Client) pollPipelineJobs(p Project, pipelineID int, topics string, ref 
 				jobName := job.Name
 				stageName := job.Stage
 				log.Debugf("Job %s for pipeline %d", jobName, pipelineID)
-				lastRunJobDuration.WithLabelValues(gp.PathWithNamespace, topics, ref, stageName, jobName).Set(float64(job.Duration))
+				lastRunJobDuration.WithLabelValues(gp.PathWithNamespace, topics, ref, stageName, jobName).Set(job.Duration)
 
 				c.outputJobStatusMetric(job.Status, p.ShouldOutputSparseStatusMetrics(cfg), gp.PathWithNamespace, topics, ref, stageName, jobName)
 
-				timeSinceLastJobRun.WithLabelValues(gp.PathWithNamespace, topics, ref, stageName, jobName).Set(float64(time.Since(*job.CreatedAt).Round(time.Second).Seconds()))
+				timeSinceLastJobRun.WithLabelValues(gp.PathWithNamespace, topics, ref, stageName, jobName).Set(time.Since(*job.CreatedAt).Round(time.Second).Seconds())
 
 				jobRunCount.WithLabelValues(gp.PathWithNamespace, topics, ref, stageName, jobName).Inc()
 
@@ -386,86 +362,145 @@ func (c *Client) pollPipelineJobs(p Project, pipelineID int, topics string, ref 
 	return err
 }
 
-func (c *Client) pollProjectRef(p Project, ref string) {
-	var gp *gitlab.Project = p.GitlabProject
-	topics := strings.Join(gp.TagList[:], ",")
+func (c *Client) pollProjectRef(p Project, ref string) error {
+	var gp = p.GitlabProject
 	var lastPipeline *gitlab.Pipeline
+	topics := strings.Join(gp.TagList[:], ",")
 
+	//FIXME is adding the counter a 0 value at every run a problem?
 	runCount.WithLabelValues(gp.PathWithNamespace, topics, ref).Add(0)
+	log.Debugf("Polling %v:%v (%v)", gp.PathWithNamespace, ref, gp.ID)
 
-	b := &backoff.Backoff{
-		Min:    time.Duration(cfg.PipelinesPollingIntervalSeconds) * time.Second,
-		Max:    time.Duration(cfg.PipelinesMaxPollingIntervalSeconds) * time.Second,
-		Factor: 1.4,
-		Jitter: false,
+	c.rateLimit()
+	pipelines, _, err := c.Pipelines.ListProjectPipelines(gp.ID, &gitlab.ListProjectPipelinesOptions{Ref: gitlab.String(ref)})
+	if err != nil {
+		return fmt.Errorf("error listing project pipelines for ref %s: %v", ref, err)
 	}
 
-	for {
-		log.Debugf("Polling %v:%v (%v)", gp.PathWithNamespace, ref, gp.ID)
+	if len(pipelines) == 0 {
+		return fmt.Errorf("could not find any pipeline for %s:%s", gp.PathWithNamespace, ref)
+	}
 
-		c.rateLimit()
-		pipelines, _, err := c.Pipelines.ListProjectPipelines(gp.ID, &gitlab.ListProjectPipelinesOptions{Ref: gitlab.String(ref)})
-		if err != nil {
-			log.Errorf("ListProjectPipelines: %s", err.Error())
-			time.Sleep(b.Duration())
-			continue
-		}
+	c.rateLimit()
+	lastPipeline, _, err = c.Pipelines.GetPipeline(gp.ID, pipelines[0].ID)
+	if err != nil {
+		return fmt.Errorf("could not read content of last pipeline %s:%s", gp.PathWithNamespace, ref)
+	}
+	if lastPipeline != nil {
+		runCount.WithLabelValues(gp.PathWithNamespace, topics, ref).Inc()
 
-		if len(pipelines) == 0 {
-			log.Debugf("Could not find any pipeline for %s:%s", gp.PathWithNamespace, ref)
-		} else if lastPipeline == nil || lastPipeline.ID != pipelines[0].ID || lastPipeline.Status != pipelines[0].Status {
-			if lastPipeline != nil {
-				runCount.WithLabelValues(gp.PathWithNamespace, topics, ref).Inc()
-			}
-
-			c.rateLimit()
-			lastPipeline, _, err = c.Pipelines.GetPipeline(gp.ID, pipelines[0].ID)
+		if lastPipeline.Coverage != "" {
+			parsedCoverage, err := strconv.ParseFloat(lastPipeline.Coverage, 64)
 			if err != nil {
-				log.Errorf("GetPipeline: %s", err.Error())
+				log.Warnf("Could not parse coverage string returned from GitLab API '%s' into Float64: %v", lastPipeline.Coverage, err)
 			}
+			coverage.WithLabelValues(gp.PathWithNamespace, topics, ref).Set(parsedCoverage)
+		}
 
-			if lastPipeline != nil {
-				if lastPipeline.Coverage != "" {
-					if parsedCoverage, err := strconv.ParseFloat(lastPipeline.Coverage, 64); err == nil {
-						coverage.WithLabelValues(gp.PathWithNamespace, topics, ref).Set(parsedCoverage)
-					} else {
-						log.Warnf("Could not parse coverage string returned from GitLab API: '%s' - '%s'", lastPipeline.Coverage, err.Error())
-					}
-				}
+		lastRunDuration.WithLabelValues(gp.PathWithNamespace, topics, ref).Set(float64(lastPipeline.Duration))
+		lastRunID.WithLabelValues(gp.PathWithNamespace, topics, ref).Set(float64(lastPipeline.ID))
 
-				lastRunDuration.WithLabelValues(gp.PathWithNamespace, topics, ref).Set(float64(lastPipeline.Duration))
-				lastRunID.WithLabelValues(gp.PathWithNamespace, topics, ref).Set(float64(lastPipeline.ID))
+		c.outputPipelineStatusMetric(lastPipeline.Status, p.ShouldOutputSparseStatusMetrics(cfg), gp.PathWithNamespace, topics, ref)
 
-				c.outputPipelineStatusMetric(lastPipeline.Status, p.ShouldOutputSparseStatusMetrics(cfg), gp.PathWithNamespace, topics, ref)
-
-				if p.ShouldFetchPipelineJobMetrics(cfg) {
-					if err := c.pollPipelineJobs(p, lastPipeline.ID, topics, ref); err != nil {
-						log.Errorf("Could not poll jobs for pipeline %d: %s", lastPipeline.ID, err.Error())
-					}
-				}
-
+		if p.ShouldFetchPipelineJobMetrics(cfg) {
+			if err := c.pollPipelineJobs(p, lastPipeline.ID, topics, ref); err != nil {
+				log.Errorf("Could not poll jobs for pipeline %d: %s", lastPipeline.ID, err.Error())
 			}
 		}
 
-		if lastPipeline != nil {
-			timeSinceLastRun.WithLabelValues(gp.PathWithNamespace, topics, ref).Set(float64(time.Since(*lastPipeline.CreatedAt).Round(time.Second).Seconds()))
-			b.Reset()
-		}
+		timeSinceLastRun.WithLabelValues(gp.PathWithNamespace, topics, ref).Set(time.Since(*lastPipeline.CreatedAt).Round(time.Second).Seconds())
+	}
 
-		time.Sleep(b.Duration())
+	return nil
+}
+
+func (c *Client) pollProjects(until <-chan bool) {
+	go func() {
+		pollWildcardsEvery := time.NewTicker(time.Duration(cfg.ProjectsPollingIntervalSeconds) * time.Second)
+		pollRefsEvery := time.NewTicker(time.Duration(cfg.RefsPollingIntervalSeconds) * time.Second)
+		stopWorkers := make(chan struct{})
+		defer close(stopWorkers)
+		// first execution
+		c.discoverWildcards()
+		c.pollWithWorkersUntil(stopWorkers)
+		for {
+			select {
+			case <-until:
+				log.Info("stopping projects polling...")
+				return
+			case <-pollRefsEvery.C:
+				c.pollWithWorkersUntil(stopWorkers)
+			case <-pollWildcardsEvery.C:
+				c.discoverWildcards()
+			}
+		}
+	}()
+}
+
+func (c *Client) discoverWildcards() {
+	log.Infof("%d wildcard(s) configured for polling", len(cfg.Wildcards))
+	if err := c.pollProjectsFromWildcards(); err != nil {
+		log.Errorf("%s", err.Error())
 	}
 }
 
-func (c *Client) pollProjects() {
-	log.Infof("%d project(s) and %d wildcard(s) configured", len(cfg.Projects), len(cfg.Wildcards))
-	for _, p := range cfg.Projects {
-		go c.pollProject(p)
+func (c *Client) pollWithWorkersUntil(stopWorkers <-chan struct{}) {
+	log.Infof("%d project(s) configured for polling", len(cfg.Projects))
+	pollErrors := c.pollProjectsWithMaxWorkers(stopWorkers, cfg.Projects...)
+	for _, err := range pollErrors {
+		log.Errorf("%v", err)
 	}
+}
 
-	for {
-		c.pollProjectsFromWildcards()
-		time.Sleep(time.Duration(cfg.ProjectsPollingIntervalSeconds) * time.Second)
+func (c *Client) pollProjectsFromWildcards() error {
+	for _, w := range cfg.Wildcards {
+		foundProjects, err := c.listProjects(&w)
+		if err != nil {
+			return fmt.Errorf("could not list projects for wildcard %v: %v", w, err)
+		}
+		for _, p := range foundProjects {
+			if !projectExists(p) {
+				log.Infof("Found new project: %s", p.Name)
+				//go c.pollProject(p) we don't need to poll projects because they will be picked up at next iteration
+				cfg.Projects = append(cfg.Projects, p)
+			}
+		}
 	}
+	return nil
+}
+
+func (c *Client) pollProjectsWithMaxWorkers(until <-chan struct{}, projects ...Project) []error {
+	var errs []error
+	errorStream := make(chan error)
+	defer close(errorStream)
+	projectsToPoll := make(chan Project, len(projects))
+	// spawn GOMAXPROCS workers to process project polling
+	for w := 0; w < runtime.GOMAXPROCS(0); w++ {
+		go func() {
+			for {
+				select {
+				case <-until:
+					return
+				case p := <-projectsToPoll:
+					if e := c.pollProject(p); e != nil {
+						errorStream <- e
+					}
+				}
+			}
+		}()
+	}
+	go func() {
+		for ex := range errorStream {
+			errs = append(errs, ex)
+		}
+	}()
+	// since the channel is buffered we can close immediately and the runtime will
+	// handle the channel close only when the messages are dispatched
+	for _, pr := range projects {
+		projectsToPoll <- pr
+	}
+	close(projectsToPoll)
+	return errs
 }
 
 func (c *Client) pollProjectRefsFromPipelines(projectID, limit int) ([]string, error) {
@@ -476,7 +511,7 @@ func (c *Client) pollProjectRefsFromPipelines(projectID, limit int) ([]string, e
 		},
 	}
 
-	refs := []string{}
+	var refs []string
 	c.rateLimit()
 	pipelines, _, err := c.Pipelines.ListProjectPipelines(projectID, options)
 	if err != nil {

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -461,7 +461,6 @@ func (c *Client) findProjectsFromWildcards() error {
 		for _, p := range foundProjects {
 			if !projectExists(p) {
 				log.Infof("Found new project: %s", p.Name)
-				//go c.pollProject(p) we don't need to poll projects because they will be picked up at next iteration
 				cfg.Projects = append(cfg.Projects, p)
 			}
 		}

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -439,8 +439,8 @@ func (c *Client) pollProjects(until <-chan bool) {
 
 func (c *Client) discoverWildcards() {
 	log.Infof("%d wildcard(s) configured for polling", len(cfg.Wildcards))
-	if err := c.pollProjectsFromWildcards(); err != nil {
-		log.Errorf("%s", err.Error())
+	if err := c.findProjectsFromWildcards(); err != nil {
+		log.Errorf("%v", err)
 	}
 }
 
@@ -452,7 +452,7 @@ func (c *Client) pollWithWorkersUntil(stopWorkers <-chan struct{}) {
 	}
 }
 
-func (c *Client) pollProjectsFromWildcards() error {
+func (c *Client) findProjectsFromWildcards() error {
 	for _, w := range cfg.Wildcards {
 		foundProjects, err := c.listProjects(&w)
 		if err != nil {


### PR DESCRIPTION
Hello,

here are addressed some of the design improvements highlighted in #86.
The main area is around pollProjects architecture that is now fully concurrent compared to the previous long-polling version.
There are also some minor cosmetic stuff like avoiding init() for metrics registry and some syntax simplifications.