### PR TITLE
Fix lingering status metrics from previous jobs

### DIFF
--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -291,17 +291,17 @@ func (c *Client) pollProject(p Project) {
 
 func outputStatusMetric(metric *prometheus.GaugeVec, labels []string, statuses []string, status string, sparseMetrics bool) {
 	// Moved into separate function to reduce cyclomatic complexity
-	args := append(labels, status)
-	if sparseMetrics {
-		metric.WithLabelValues(args...).Set(1)
-	} else {
-		// List of available statuses from the API spec
-		// ref: https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs
-		for _, s := range statuses {
-			if s == status {
-				metric.WithLabelValues(args...).Set(1)
+	// List of available statuses from the API spec
+	// ref: https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs
+	for _, s := range statuses {
+		args := append(labels, s)
+		if s == status {
+			metric.WithLabelValues(args...).Set(1)
+		} else {
+			if sparseMetrics {
+				metric.DeleteLabelValues(args...)
 			} else {
-				metric.WithLabelValues(append(labels, s)...).Set(0)
+				metric.WithLabelValues(args...).Set(0)
 			}
 		}
 	}


### PR DESCRIPTION
If a job sees multiple statuses with the exporter continuing to run, it will report all those statuses being set to 1 when sparse status metrics are enabled because the metric 'entries' from previous statuses and labels are stored in memory for the lifetime of the program if not deleted.

This PR changes the status metric code so that if sparse metrics are on, we just delete the dimensions of status plus labels when they dont match the current status rather than explicitly setting them to zero.