### PR TITLE
resolves #90: using sync to coordinate error passing in projects polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 **/.DS_Store
 gitlab-ci-pipelines-exporter
 coverage.out
+.test

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ misspell: setup ## Test code with misspell
 
 .PHONY: test
 test: ## Run the tests against the codebase
-	go test -v ./...
+	go test -v -race ./...
 
 .PHONY: install
 install: ## Build and install locally the binary (dev purpose)

--- a/cmd/gitlab_test.go
+++ b/cmd/gitlab_test.go
@@ -227,3 +227,22 @@ func pollingResult(until <-chan struct{}, projects <-chan Project, client *Clien
 	}
 	return numErrs
 }
+
+func TestClient_pollProjectsWith(t *testing.T) {
+	c := Client{}
+	message := "some error"
+	doing := func(Project) error {
+		return fmt.Errorf(message)
+	}
+	testProjects := []Project{{Name: "test"}, {Name: "test2"}, {Name: "test4"}, {Name: "test4"}}
+	until := make(chan struct{})
+	errCh := c.pollProjectsWith(4, doing, until, testProjects...)
+	var errCount int
+	for err := range errCh {
+		if assert.Error(t, err) {
+			assert.Equal(t, err.Error(), message)
+			errCount++
+		}
+	}
+	assert.Equal(t, len(testProjects), errCount)
+}


### PR DESCRIPTION
Here a correction to the previous impementation of concurrent polling mentioned in #88 but that caused #90 due to missing coordination on closing the channel.
Added a `sync.Waitgroup` to let the polling goroutines complete sending the error before closing the output channel.
Improved the signature of the method to make it testable in isolation