### PR TITLE
Adding pipeline variables metrics & refactored general logic implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,5 @@ vendor
 **/.DS_Store
 gitlab-ci-pipelines-exporter
 coverage.out
-<<<<<<< HEAD
 testconfig.yml
-=======
 .test
->>>>>>> e549ae4123917b2f785c3df9687d7b9da28d71bf

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ vendor
 **/.DS_Store
 gitlab-ci-pipelines-exporter
 coverage.out
-.test
+testconfig.yml

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ vendor
 **/.DS_Store
 gitlab-ci-pipelines-exporter
 coverage.out
-testconfig.yml
-.test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [0ver](https://0ver.org).
 
 ### Added
 
-- Configuration for OpenMetrics Encoding in metrics HTTP endpoint. Enabled by default but can be disable using `disable_openmetrics_encoding: true`.
+- Configuration for OpenMetrics Encoding in metrics HTTP endpoint. Enabled by default but can be disable using `disable_openmetrics_encoding: true`
 - Worker pool for projects polling: set `maximum_projects_poller_workers` with an integer value to control parallelism (defaults to `runtime.GOMAXPROCS(0)`)  
 - Augmented `disable_tls_verify` with `disable_health_check` additional parameter to drive the behaviour of checking healthiness of target service 
+- New metric `gitlab_ci_pipeline_run_count_with_variable`: it stores the comma-separated list of variables as a label named `pipeline_variables`
+- Reading pipeline variables if enabled setting `fetch_pipeline_variables` to `true` (defaults to `false`)
+- Pipeline variables can be filtered with `pipeline_variables_filter_regex` (defaults to `.*`)
 - Configurable ServiceMonitor resource through the helm chart
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [0ver](https://0ver.org).
 - Configuration for OpenMetrics Encoding in metrics HTTP endpoint. Enabled by default but can be disable using `disable_openmetrics_encoding: true`.
 - Worker pool for projects polling: set `maximum_projects_poller_workers` with an integer value to control parallelism (defaults to `runtime.GOMAXPROCS(0)`)  
 - Configurable ServiceMonitor resource through the helm chart
+- Augmented `skip_tls_verify` with `skip_health_check` additional parameter to drive the behaviour of checking healthiness of target service
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [0ver](https://0ver.org).
 
 - Configuration for OpenMetrics Encoding in metrics HTTP endpoint. Enabled by default but can be disable using `disable_openmetrics_encoding: true`.
 - Worker pool for projects polling: set `maximum_projects_poller_workers` with an integer value to control parallelism (defaults to `runtime.GOMAXPROCS(0)`)  
-- Augmented `skip_tls_verify` with `skip_health_check` additional parameter to drive the behaviour of checking healthiness of target service 
+- Augmented `disable_tls_verify` with `disable_health_check` additional parameter to drive the behaviour of checking healthiness of target service 
 - Configurable ServiceMonitor resource through the helm chart
 
 ### Changed
@@ -142,7 +142,7 @@ if not seen in a long time.
 ### Added
 
 - New `gitlab_ci_pipeline_last_run_id` metric
-- Added `skip_tls_verify` config parameter for the GitLab client
+- Added `disable_tls_verify` config parameter for the GitLab client
 - Added `-c` and `-l` aliases for `config` and `listen-adress` flags
 - Backoff mechanism for pollings refs with no pipelines
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,7 @@ gitlab:
   
   # disable verification of readiness for target GitLab instance calling `health_url`
   # skip_health_check: false
-<<<<<<< HEAD
 
-=======
-  
->>>>>>> e549ae4123917b2f785c3df9687d7b9da28d71bf
   # disable TLS validation for target GitLab instance (handy when self-hosting)
   # skip_tls_verify: false
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ pipelines_polling_interval_seconds: 60
 # Sets the parallelism for polling projects from the API (default to available CPUs: runtime.GOMAXPROCS(0))
 # maximum_projects_poller_workers: 1
 
-# Enable OpenMetrics content encoding in prometheus HTTP handler (default: true)
+# Disable OpenMetrics content encoding in prometheus HTTP handler (default: false)
 # see: https://godoc.org/github.com/prometheus/client_golang/prometheus/promhttp#HandlerOpts
-# prometheus_openmetrics_encoding: true
+# disable_openmetrics_encoding: true
 
 # Whether to attempt retrieving refs from pipelines when the exporter starts (default: false)
 on_init_fetch_refs_from_pipelines: false
@@ -67,6 +67,12 @@ output_sparse_status_metrics: false
 
 # Default regexp for parsing the refs (branches and tags) to monitor (optional, default to master)
 # default_refs: "^master$"
+
+# Fetch pipeline variables in a separate metric (default: false)
+# fetch_pipeline_variables: true
+
+# Filter refs (branches/tags) to include in pipeline variables scanning (default: ".*", all refs)
+# pipeline_variables_filter_regex: "^(master|dev|feature-123)$"
 
 # The list of the projects you want to monitor
 projects:

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ gitlab:
   # health_url: https://gitlab.example.com/-/health
   
   # disable verification of readiness for target GitLab instance calling `health_url`
-  # skip_health_check: false
+  # disable_health_check: false
 
   # disable TLS validation for target GitLab instance (handy when self-hosting)
-  # skip_tls_verify: false
+  # disable_tls_verify: false
 
 # Global rate limit for the GitLab API request/sec
 maximum_gitlab_api_requests_per_second: 10

--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ gitlab:
   # Alternative URL for determining health of GitLab API (readiness probe)
   # health_url: https://gitlab.example.com/-/health
   
-  # disable TLS verification
+  # disable verification of readiness for target GitLab instance calling `health_url`
+  # skip_health_check: false
+
+  # disable TLS validation for target GitLab instance (handy when self-hosting)
   # skip_tls_verify: false
 
 # Global rate limit for the GitLab API request/sec

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	RefsPollingIntervalSeconds             int        `yaml:"refs_polling_interval_seconds"`                 // Interval in seconds to fetch refs from projects
 	PipelinesPollingIntervalSeconds        int        `yaml:"pipelines_polling_interval_seconds"`            // Interval in seconds to get new pipelines from refs (exponentially backing of to maximum value)
 	FetchPipelineJobMetrics                bool       `yaml:"fetch_pipeline_job_metrics"`                    // Whether to attempt to retrieve job metrics from polled pipelines
+	FetchPipelineVariables                 bool       `yaml:"fetch_pipeline_variables"`                      // Whether to attempt to retrieve variables included in the pipeline execution
+	PipelineVariablesFilterRegexp          string     `yaml:"pipeline_variables_filter_regex"`               // Regex to filter pipeline variables, deafaults to '.*'
 	OutputSparseStatusMetrics              bool       `yaml:"output_sparse_status_metrics"`                  // Whether to report all pipeline / job statuses, or only report the one from the last job.
 	OnInitFetchRefsFromPipelines           bool       `yaml:"on_init_fetch_refs_from_pipelines"`             // Whether to attempt retrieving refs from pipelines when the exporter starts
 	OnInitFetchRefsFromPipelinesDepthLimit int        `yaml:"on_init_fetch_refs_from_pipelines_depth_limit"` // Maximum number of pipelines to analyze per project to search for refs on init (default: 100)
@@ -68,6 +70,8 @@ const (
 
 	errNoProjectsOrWildcardConfigured = "you need to configure at least one project/wildcard to poll, none given"
 	errConfigFileNotFound             = "couldn't open config file : %v"
+
+	variablesCatchallRegex = "\\.*"
 )
 
 var cfg = &Config{}
@@ -137,6 +141,10 @@ func (cfg *Config) Parse(path string) error {
 
 	if cfg.MaximumProjectsPollingWorkers == 0 {
 		cfg.MaximumProjectsPollingWorkers = runtime.GOMAXPROCS(0)
+	}
+
+	if cfg.PipelineVariablesFilterRegexp == "" {
+		cfg.PipelineVariablesFilterRegexp = variablesCatchallRegex
 	}
 
 	return nil

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -13,11 +13,11 @@ import (
 // Config represents what can be defined as a yaml config file
 type Config struct {
 	Gitlab struct {
-		URL             string `yaml:"url"`               // The URL of the GitLab server/api (default to https://gitlab.com)
-		Token           string `yaml:"token"`             // Token to use to authenticate against the API
-		HealthURL       string `yaml:"health_url"`        // The URL of the GitLab server/api health endpoint (default to /users/sign_in which is publicly available on gitlab.com)
-		SkipHealthCheck bool   `yaml:"skip_health_check"` // Whether to validate the service is reachable calling HealthURL
-		SkipTLSVerify   bool   `yaml:"skip_tls_verify"`   // Whether to skip TLS validation when querying HealthURL
+		URL                string `yaml:"url"`                  // The URL of the GitLab server/api (default to https://gitlab.com)
+		Token              string `yaml:"token"`                // Token to use to authenticate against the API
+		HealthURL          string `yaml:"health_url"`           // The URL of the GitLab server/api health endpoint (default to /users/sign_in which is publicly available on gitlab.com)
+		DisableHealthCheck bool   `yaml:"disable_health_check"` // Whether to validate the service is reachable calling HealthURL
+		DisableTLSVerify   bool   `yaml:"disable_tls_verify"`   // Whether to skip TLS validation when querying HealthURL
 	}
 
 	MaximumGitLabAPIRequestsPerSecond      int        `yaml:"maximum_gitlab_api_requests_per_second"`        // Maximum amount of requests per seconds to make against the GitLab API (default: 10)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -13,10 +13,11 @@ import (
 // Config represents what can be defined as a yaml config file
 type Config struct {
 	Gitlab struct {
-		URL           string `yaml:"url"`             // The URL of the GitLab server/api (default to https://gitlab.com)
-		Token         string `yaml:"token"`           // Token to use to authenticate against the API
-		HealthURL     string `yaml:"health_url"`      // The URL of the GitLab server/api health endpoint (default to /users/sign_in which is publicly available on gitlab.com)
-		SkipTLSVerify bool   `yaml:"skip_tls_verify"` // Whether to validate TLS certificates or not
+		URL             string `yaml:"url"`               // The URL of the GitLab server/api (default to https://gitlab.com)
+		Token           string `yaml:"token"`             // Token to use to authenticate against the API
+		HealthURL       string `yaml:"health_url"`        // The URL of the GitLab server/api health endpoint (default to /users/sign_in which is publicly available on gitlab.com)
+		SkipHealthCheck bool   `yaml:"skip_health_check"` // Whether to validate the service is reachable calling HealthURL
+		SkipTLSVerify   bool   `yaml:"skip_tls_verify"`   // Whether to skip TLS validation when querying HealthURL
 	}
 
 	MaximumGitLabAPIRequestsPerSecond      int        `yaml:"maximum_gitlab_api_requests_per_second"`        // Maximum amount of requests per seconds to make against the GitLab API (default: 10)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 
 	"github.com/urfave/cli"
-	"github.com/xanzy/go-gitlab"
 	"gopkg.in/yaml.v3"
 )
 
@@ -43,7 +42,6 @@ type Project struct {
 	Refs                      string `yaml:"refs"`
 	FetchPipelineJobMetrics   *bool  `yaml:"fetch_pipeline_job_metrics,omitempty"`
 	OutputSparseStatusMetrics *bool  `yaml:"output_sparse_status_metrics,omitempty"`
-	GitlabProject             *gitlab.Project
 }
 
 // Wildcard is a specific handler to dynamically search projects

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -175,6 +175,7 @@ projects:
 		OnInitFetchRefsFromPipelinesDepthLimit: defaultOnInitFetchRefsFromPipelinesDepthLimit,
 		DefaultRefsRegexp:                      "",
 		MaximumProjectsPollingWorkers:          runtime.GOMAXPROCS(0),
+		FetchPipelineVariables:                 false,
 		PipelineVariablesFilterRegexp:          variablesCatchallRegex,
 		Projects: []Project{
 			{

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"runtime"
-
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,7 +51,7 @@ gitlab:
   url: https://gitlab.example.com
   token: xrN14n9-ywvAFxxxxxx
   health_url: https://gitlab.example.com/-/health
-  skip_tls_verify: true
+  skip_health_check: true
 
 maximum_gitlab_api_requests_per_second: 1
 projects_polling_interval_seconds: 2
@@ -85,15 +84,16 @@ wildcards:
 
 	expectedCfg := Config{
 		Gitlab: struct {
-			URL           string "yaml:\"url\""
-			Token         string "yaml:\"token\""
-			HealthURL     string "yaml:\"health_url\""
-			SkipTLSVerify bool   "yaml:\"skip_tls_verify\""
+			URL             string "yaml:\"url\""
+			Token           string "yaml:\"token\""
+			HealthURL       string "yaml:\"health_url\""
+			SkipHealthCheck bool   "yaml:\"skip_health_check\""
+			SkipTLSVerify   bool   "yaml:\"skip_tls_verify\""
 		}{
-			URL:           "https://gitlab.example.com",
-			HealthURL:     "https://gitlab.example.com/-/health",
-			Token:         "xrN14n9-ywvAFxxxxxx",
-			SkipTLSVerify: true,
+			URL:             "https://gitlab.example.com",
+			HealthURL:       "https://gitlab.example.com/-/health",
+			Token:           "xrN14n9-ywvAFxxxxxx",
+			SkipHealthCheck: true,
 		},
 		MaximumGitLabAPIRequestsPerSecond:      1,
 		ProjectsPollingIntervalSeconds:         2,
@@ -154,15 +154,15 @@ projects:
 
 	expectedCfg := Config{
 		Gitlab: struct {
-			URL           string "yaml:\"url\""
-			Token         string "yaml:\"token\""
-			HealthURL     string "yaml:\"health_url\""
-			SkipTLSVerify bool   "yaml:\"skip_tls_verify\""
+			URL             string "yaml:\"url\""
+			Token           string "yaml:\"token\""
+			HealthURL       string "yaml:\"health_url\""
+			SkipHealthCheck bool   "yaml:\"skip_health_check\""
+			SkipTLSVerify   bool   "yaml:\"skip_tls_verify\""
 		}{
-			URL:           "https://gitlab.com",
-			Token:         "",
-			HealthURL:     "https://gitlab.com/users/sign_in",
-			SkipTLSVerify: false,
+			URL:       "https://gitlab.com",
+			Token:     "",
+			HealthURL: "https://gitlab.com/users/sign_in",
 		},
 		MaximumGitLabAPIRequestsPerSecond:      defaultMaximumGitLabAPIRequestsPerSecond,
 		ProjectsPollingIntervalSeconds:         defaultProjectsPollingIntervalSeconds,

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -51,7 +51,7 @@ gitlab:
   url: https://gitlab.example.com
   token: xrN14n9-ywvAFxxxxxx
   health_url: https://gitlab.example.com/-/health
-  skip_health_check: true
+  disable_health_check: true
 
 maximum_gitlab_api_requests_per_second: 1
 projects_polling_interval_seconds: 2
@@ -84,16 +84,16 @@ wildcards:
 
 	expectedCfg := Config{
 		Gitlab: struct {
-			URL             string "yaml:\"url\""
-			Token           string "yaml:\"token\""
-			HealthURL       string "yaml:\"health_url\""
-			SkipHealthCheck bool   "yaml:\"skip_health_check\""
-			SkipTLSVerify   bool   "yaml:\"skip_tls_verify\""
+			URL                string "yaml:\"url\""
+			Token              string "yaml:\"token\""
+			HealthURL          string "yaml:\"health_url\""
+			DisableHealthCheck bool   "yaml:\"disable_health_check\""
+			DisableTLSVerify   bool   "yaml:\"disable_tls_verify\""
 		}{
-			URL:             "https://gitlab.example.com",
-			HealthURL:       "https://gitlab.example.com/-/health",
-			Token:           "xrN14n9-ywvAFxxxxxx",
-			SkipHealthCheck: true,
+			URL:                "https://gitlab.example.com",
+			HealthURL:          "https://gitlab.example.com/-/health",
+			Token:              "xrN14n9-ywvAFxxxxxx",
+			DisableHealthCheck: true,
 		},
 		MaximumGitLabAPIRequestsPerSecond:      1,
 		ProjectsPollingIntervalSeconds:         2,
@@ -154,11 +154,11 @@ projects:
 
 	expectedCfg := Config{
 		Gitlab: struct {
-			URL             string "yaml:\"url\""
-			Token           string "yaml:\"token\""
-			HealthURL       string "yaml:\"health_url\""
-			SkipHealthCheck bool   "yaml:\"skip_health_check\""
-			SkipTLSVerify   bool   "yaml:\"skip_tls_verify\""
+			URL                string "yaml:\"url\""
+			Token              string "yaml:\"token\""
+			HealthURL          string "yaml:\"health_url\""
+			DisableHealthCheck bool   "yaml:\"disable_health_check\""
+			DisableTLSVerify   bool   "yaml:\"disable_tls_verify\""
 		}{
 			URL:       "https://gitlab.com",
 			Token:     "",

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -72,10 +72,10 @@ func Run(ctx *cli.Context) error {
 	signal.Notify(onShutdown, syscall.SIGINT, syscall.SIGTERM, syscall.SIGABRT)
 
 	untilStopSignal := make(chan bool)
-	refsOnInit := make(chan bool)
-	c.orchestratePolling(untilStopSignal, refsOnInit)
+	pipelinesOnInit := make(chan bool)
+	c.orchestratePolling(untilStopSignal, pipelinesOnInit)
 	// get immediately some data from the latest executed pipelines, if configured to do so
-	refsOnInit <- cfg.OnInitFetchRefsFromPipelines
+	pipelinesOnInit <- cfg.OnInitFetchRefsFromPipelines
 
 	// Configure liveness and readiness probes
 	health := healthcheck.NewHandler()

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -53,7 +53,7 @@ func Run(ctx *cli.Context) error {
 	// Configure GitLab client
 	opts := []gitlab.ClientOptionFunc{
 		gitlab.WithHTTPClient(&http.Client{Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.Gitlab.SkipTLSVerify},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.Gitlab.DisableTLSVerify},
 		}}),
 		gitlab.WithBaseURL(cfg.Gitlab.URL),
 	}
@@ -79,7 +79,7 @@ func Run(ctx *cli.Context) error {
 
 	// Configure liveness and readiness probes
 	health := healthcheck.NewHandler()
-	if !cfg.Gitlab.SkipHealthCheck {
+	if !cfg.Gitlab.DisableHealthCheck {
 		health.AddReadinessCheck("gitlab-reachable", healthcheck.HTTPGetCheck(cfg.Gitlab.HealthURL, 5*time.Second))
 	} else {
 		log.Warn("GitLab health check has been disabled. Readiness checks won't be operated.")

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -83,13 +83,13 @@ func Run(ctx *cli.Context) error {
 	}
 
 	// Register the default metrics into a new registry
-	registerMetricOn(registry, log.StandardLogger(), defaultMetrics...)
+	registerMetricOn(registry, defaultMetrics...)
 
 	// Expose the registered registry via HTTP
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health/live", health.LiveEndpoint)
 	mux.HandleFunc("/health/ready", health.ReadyEndpoint)
-	mux.Handle("/metrics", metricsHandlerFor(registry, cfg.PrometheusOpenmetricsEncoding))
+	mux.Handle("/metrics", metricsHandlerFor(registry, cfg.DisableOpenmetricsEncoding))
 
 	srv := &http.Server{
 		Addr:    ctx.GlobalString("listen-address"),

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -82,7 +82,7 @@ func Run(ctx *cli.Context) error {
 	if !cfg.Gitlab.SkipHealthCheck {
 		health.AddReadinessCheck("gitlab-reachable", healthcheck.HTTPGetCheck(cfg.Gitlab.HealthURL, 5*time.Second))
 	} else {
-		log.Warn("TLS verification has been disabled. Readiness checks won't be operated.")
+		log.Warn("GitLab health check has been disabled. Readiness checks won't be operated.")
 	}
 
 	// Register the default metrics into a new registry

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -72,7 +72,10 @@ func Run(ctx *cli.Context) error {
 	signal.Notify(onShutdown, syscall.SIGINT, syscall.SIGTERM, syscall.SIGABRT)
 
 	untilStopSignal := make(chan bool)
-	c.pollProjects(untilStopSignal)
+	refsOnInit := make(chan bool)
+	c.orchestratePolling(untilStopSignal, refsOnInit)
+	// get immediately some data from the latest executed pipelines, if configured to do so
+	refsOnInit <- cfg.OnInitFetchRefsFromPipelines
 
 	// Configure liveness and readiness probes
 	health := healthcheck.NewHandler()

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -119,9 +119,10 @@ var (
 	)
 )
 
-func newMetricsRegistry() *prometheus.Registry {
+func newMetricsRegistry(metrics ...prometheus.Collector) *prometheus.Registry {
 	registry := prometheus.NewRegistry()
 
+	//default metrics
 	registry.MustRegister(coverage)
 	registry.MustRegister(lastRunDuration)
 	registry.MustRegister(lastRunID)
@@ -134,13 +135,14 @@ func newMetricsRegistry() *prometheus.Registry {
 	registry.MustRegister(timeSinceLastJobRun)
 	registry.MustRegister(lastRunJobArtifactSize)
 
+	for _, m := range metrics {
+		registry.MustRegister(m)
+	}
 	return registry
 }
 
 // Run launches the exporter
 func Run(ctx *cli.Context) error {
-	// register metrics
-	metrics := newMetricsRegistry()
 
 	// Configure logger
 	lc := &logger.Config{
@@ -202,14 +204,13 @@ func Run(ctx *cli.Context) error {
 		log.Warn("TLS verification has been disabled. Readiness checks won't be operated.")
 	}
 
-	// Expose the registered metrics via HTTP
+	// register registry
+	registry := newMetricsRegistry()
+	// Expose the registered registry via HTTP
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health/live", health.LiveEndpoint)
 	mux.HandleFunc("/health/ready", health.ReadyEndpoint)
-	mux.Handle("/metrics", promhttp.HandlerFor(metrics, promhttp.HandlerOpts{
-		Registry:          metrics,
-		EnableOpenMetrics: !cfg.DisableOpenmetricsEncoding,
-	}))
+	mux.Handle("/registry", metricsHandlerFor(registry, cfg.PrometheusOpenmetricsEncoding))
 
 	srv := &http.Server{
 		Addr:    ctx.GlobalString("listen-address"),
@@ -235,6 +236,13 @@ func Run(ctx *cli.Context) error {
 	}
 
 	return exit(nil, 0)
+}
+
+func metricsHandlerFor(metrics *prometheus.Registry, openMetricsEncoder bool) http.Handler {
+	return promhttp.HandlerFor(metrics, promhttp.HandlerOpts{
+		Registry:          metrics,
+		EnableOpenMetrics: openMetricsEncoder,
+	})
 }
 
 func exit(err error, exitCode int) *cli.ExitError {

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -134,10 +134,10 @@ func gitlabReadinessCheck(httpClient *http.Client, url string) healthcheck.Check
 	}
 }
 
-func metricsHandlerFor(registry *prometheus.Registry, openMetricsEncoder bool) http.Handler {
+func metricsHandlerFor(registry *prometheus.Registry, disableOpenMetricsEncoder bool) http.Handler {
 	return promhttp.HandlerFor(registry, promhttp.HandlerOpts{
 		Registry:          registry,
-		EnableOpenMetrics: openMetricsEncoder,
+		EnableOpenMetrics: !disableOpenMetricsEncoder,
 	})
 }
 

--- a/cmd/exporter_test.go
+++ b/cmd/exporter_test.go
@@ -40,38 +40,3 @@ func TestRunInvalidConfigFile(t *testing.T) {
 	assert.Equal(t, true, strings.HasPrefix(err.Error(), "couldn't open config file :"))
 }
 
-// introduce a test to check the /metrics endpoint body
-func TestMetricsRegistryContainsMetricsWhenSet(t *testing.T) {
-	// a custom additional metric added to the registry
-	some := "test_something"
-	aCounter := prometheus.NewCounter(prometheus.CounterOpts{Name: some})
-	registry := newMetricsRegistry(nil, aCounter)
-
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
-	metricsHandlerFor(registry, false).ServeHTTP(w, r)
-
-	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
-	assert.Contains(t, w.Body.String(), some)
-}
-
-func TestAMetricCanBeAddedLabelDynamically(t *testing.T) {
-	// a custom additional metric added to the registry
-	counter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_something"}, []string{"first", "second"})
-	prometheus.MustRegister(counter)
-
-	curriedCounter, err := counter.CurryWith(prometheus.Labels{"first": "0", "second": "something"})
-	if assert.Nil(t, err) {
-		assert.Contains(t, curriedCounter.WithLabelValues().Desc().String(), "something")
-	}
-}
-
-func TestAVaribleConstMetricIsUpdated(t *testing.T) {
-	someVars := []gitlab.PipelineVariable{{Key: "test", Value: "testval"}, {Key: "test-2", Value: "aaaa", VariableType: "env_var"}}
-
-	counter := variableLabelledCounter(someVars)
-	assert.Contains(t, counter.Desc().String(), "test")
-	assert.Contains(t, counter.Desc().String(), "test-2")
-	assert.NotContains(t, counter.Desc().String(), "testval")
-
-}

--- a/cmd/exporter_test.go
+++ b/cmd/exporter_test.go
@@ -3,15 +3,11 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
-	"github.com/xanzy/go-gitlab"
 )
 
 func TestRunWrongLogLevel(t *testing.T) {
@@ -39,4 +35,3 @@ func TestRunInvalidConfigFile(t *testing.T) {
 	err := Run(cli.NewContext(nil, set, nil))
 	assert.Equal(t, true, strings.HasPrefix(err.Error(), "couldn't open config file :"))
 }
-

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -229,7 +229,7 @@ func (c *Client) pollProject(p Project) error {
 	log.Debugf("Fetching project : %s", p.Name)
 	p.GitlabProject, err = c.getProject(p.Name)
 	if err != nil {
-		return fmt.Errorf("unable to fetch project '%s' from the GitLab API : %v", p.Name, err.Error())
+		return fmt.Errorf("unable to fetch project '%s' from the GitLab API: %v", p.Name, err.Error())
 	}
 
 	if cfg.OnInitFetchRefsFromPipelines {
@@ -450,6 +450,7 @@ func (c *Client) pollWithWorkersUntil(stop <-chan struct{}) {
 		if err != nil {
 			log.Errorf("%v", err)
 		}
+
 	}
 }
 

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -242,7 +242,7 @@ func (c *Client) discoverWildcards() {
 func (c *Client) pollPipelinesOnInit() {
 	log.Debug("Polling latest pipelines to get data out of them")
 	for _, p := range cfg.Projects {
-		log.Debug("On init: reading project %s",p.Name)
+		log.Debugf("On init: reading project %s", p.Name)
 		gitlabProject, err := c.getProject(p.Name)
 		if err != nil {
 			log.Errorf("could not get GitLab project with name %s: %v", p.Name, err)

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -153,6 +153,9 @@ func (c *Client) pollProjectRefOn(gp *gitlab.Project, ref string, outputSparseSt
 	topics := strings.Join(gp.TagList[:], ",")
 	runCount.WithLabelValues(gp.PathWithNamespace, topics, ref).Add(0)
 
+	if len(pipelines) == 0 {
+		return fmt.Errorf("could not find any pipeline run in project %s", gp.PathWithNamespace)
+	}
 	c.rateLimit()
 	lastPipeline, _, err := c.Pipelines.GetPipeline(gp.ID, pipelines[0].ID)
 	if err != nil {

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/ratelimit"
 )
 
-var statusesList = []string{"running", "pending", "success", "failed", "canceled", "skipped", "manual"}
+var statusesList = [...]string{"running", "pending", "success", "failed", "canceled", "skipped", "manual"}
 
 var has = func(item interface{}, list []interface{}) bool {
 	for _, i := range list {

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/ratelimit"
 )
 
-var statusesList = [...]string{"running", "pending", "success", "failed", "canceled", "skipped", "manual"}
+var statusesList = []string{"running", "pending", "success", "failed", "canceled", "skipped", "manual"}
 
 var has = func(item interface{}, list []interface{}) bool {
 	for _, i := range list {

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -450,7 +450,6 @@ func (c *Client) pollWithWorkersUntil(stop <-chan struct{}) {
 		if err != nil {
 			log.Errorf("%v", err)
 		}
-
 	}
 }
 

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -69,7 +69,7 @@ func (c *Client) pollProject(p Project) error {
 	for _, r := range branchesAndTagRefs {
 		log.Infof("Found ref '%s' for project '%s'", r, p.Name)
 		if err := c.pollProjectRefOn(project, r, p.ShouldOutputSparseStatusMetrics(cfg), p.ShouldFetchPipelineJobMetrics(cfg)); err != nil {
-			log.Errorf("Error getting pipeline data on ref '%s' for project '%s'", r, p.Name)
+			log.Errorf("Error getting pipeline data on ref '%s' for project '%s': %v", r, p.Name, err)
 			continue
 		}
 	}

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -248,12 +248,12 @@ func (c *Client) pollPipelinesOnInit() {
 			log.Errorf("could not get GitLab project with name %s: %v", p.Name, err)
 			continue
 		}
-		pipeRefs, err := c.refsFromPipelines(gitlabProject, cfg.OnInitFetchRefsFromPipelinesDepthLimit)
+		pipelineRefs, err := c.refsFromPipelines(gitlabProject, cfg.OnInitFetchRefsFromPipelinesDepthLimit)
 		if err != nil {
 			log.Errorf("unable to fetch refs from project pipelines %s : %v", p.Name, err.Error())
 			continue
 		}
-		for _, r := range pipeRefs {
+		for _, r := range pipelineRefs {
 			if err := c.pollProjectRefOn(gitlabProject, r, false, false); err != nil {
 				log.Errorf("%v", err)
 			}

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -235,12 +235,12 @@ func (c *Client) pollProject(p Project) error {
 	// search for refs on pipelines if requested
 	if cfg.OnInitFetchRefsFromPipelines {
 		log.Debugf("Polling project refs %s from most recent %d pipelines", p.Name, cfg.OnInitFetchRefsFromPipelinesDepthLimit)
-		pipeleRefs, err := c.refsFromPipelines(p.GitlabProject.ID, cfg.OnInitFetchRefsFromPipelinesDepthLimit)
+		pipelineRefs, err := c.refsFromPipelines(p.GitlabProject.ID, cfg.OnInitFetchRefsFromPipelinesDepthLimit)
 		if err != nil {
 			return fmt.Errorf("unable to fetch refs from project pipelines %s : %v", p.Name, err.Error())
 		}
 		// append to refs the entries found on init
-		refs = append(refs, pipeleRefs...)
+		refs = append(refs, pipelineRefs...)
 	}
 	// append to refs the entries from branches and tags
 	branchesAndTagRefs, err := c.branchesAndTagsFor(p.GitlabProject.ID, p.Refs)

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -10,9 +10,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/xanzy/go-gitlab"
-
 	log "github.com/sirupsen/logrus"
+	"github.com/xanzy/go-gitlab"
 )
 
 var statusesList = []string{"running", "pending", "success", "failed", "canceled", "skipped", "manual"}
@@ -223,48 +222,41 @@ func (c *Client) tagNamesFor(projectID int) ([]*string, error) {
 }
 
 func (c *Client) pollProject(p Project) error {
-	var polledRefs []string
-	var err error
 
 	log.Debugf("Fetching project : %s", p.Name)
-	p.GitlabProject, err = c.getProject(p.Name)
+	project, err := c.getProject(p.Name)
 	if err != nil {
 		return fmt.Errorf("unable to fetch project '%s' from the GitLab API: %v", p.Name, err.Error())
 	}
+	p.GitlabProject = project
 
+	// create a list of refs to analyze
+	var refs []string
+	// search for refs on pipelines if requested
 	if cfg.OnInitFetchRefsFromPipelines {
-		log.Debugf("Polling project refs %s from most recent %d pipelines (init only)", p.Name, cfg.OnInitFetchRefsFromPipelinesDepthLimit)
-		refs, err := c.pollProjectRefsFromPipelines(p.GitlabProject.ID, cfg.OnInitFetchRefsFromPipelinesDepthLimit)
+		log.Debugf("Polling project refs %s from most recent %d pipelines", p.Name, cfg.OnInitFetchRefsFromPipelinesDepthLimit)
+		pipeleRefs, err := c.refsFromPipelines(p.GitlabProject.ID, cfg.OnInitFetchRefsFromPipelinesDepthLimit)
 		if err != nil {
 			return fmt.Errorf("unable to fetch refs from project pipelines %s : %v", p.Name, err.Error())
 		}
+		// append to refs the entries found on init
+		refs = append(refs, pipeleRefs...)
+	}
+	// append to refs the entries from branches and tags
+	branchesAndTagRefs, err := c.branchesAndTagsFor(p.GitlabProject.ID, p.Refs)
+	if err != nil {
+		return fmt.Errorf("error fetching refs for project '%s'", p.Name)
+	}
+	refs = append(refs, branchesAndTagRefs...)
 
-		log.Debugf("Found %d refs from %s pipelines", len(refs), p.Name)
+	// read the metrics for refs
+	log.Debugf("Polling refs for project : %s", p.Name)
+	if len(refs) > 0 {
 		for _, r := range refs {
 			log.Infof("Found ref '%s' for project '%s'", r, p.Name)
 			if err := c.pollProjectRef(p, r); err != nil {
 				log.Errorf("Error getting pipeline data on ref '%s' for project '%s'", r, p.Name)
 				continue
-			}
-			polledRefs = append(polledRefs, r)
-		}
-	}
-	log.Debugf("Polling refs for project : %s", p.Name)
-
-	refs, err := c.branchesAndTagsFor(p.GitlabProject.ID, p.Refs)
-	if err != nil {
-		return fmt.Errorf("error fetching refs for project '%s'", p.Name)
-	}
-
-	if len(refs) > 0 {
-		for _, r := range refs {
-			if !refExists(r, polledRefs) {
-				log.Infof("Found ref '%s' for project '%s'", r, p.Name)
-				if err := c.pollProjectRef(p, r); err != nil {
-					log.Errorf("Error getting pipeline data on ref '%s' for project '%s'", r, p.Name)
-					continue
-				}
-				polledRefs = append(polledRefs, r)
 			}
 		}
 	}
@@ -504,7 +496,7 @@ func (c *Client) pollProjectsWith(numWorkers int, fetch func(Project) error, unt
 	return errorStream
 }
 
-func (c *Client) pollProjectRefsFromPipelines(projectID, limit int) ([]string, error) {
+func (c *Client) refsFromPipelines(projectID, limit int) ([]string, error) {
 	options := &gitlab.ListProjectPipelinesOptions{
 		ListOptions: gitlab.ListOptions{
 			Page:    1,
@@ -520,10 +512,9 @@ func (c *Client) pollProjectRefsFromPipelines(projectID, limit int) ([]string, e
 	}
 
 	for _, p := range pipelines {
-		if refExists(p.Ref, refs) {
-			continue
+		if !refExists(p.Ref, refs) {
+			refs = append(refs, p.Ref)
 		}
-		refs = append(refs, p.Ref)
 	}
 
 	return refs, nil
@@ -535,4 +526,14 @@ func (c *Client) rateLimit() {
 	if throttled.Sub(now).Milliseconds() > 10 {
 		log.Debugf("throttled polling requests for %v", throttled.Sub(now))
 	}
+}
+
+func variableLabelledCounter(vars []gitlab.PipelineVariable) prometheus.Counter {
+	var labels []string
+	for _, v := range vars {
+		labels = append(labels, v.Key)
+	}
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_vars"}, labels).WithLabelValues(labels...)
+	counter.Add(1.0)
+	return counter
 }

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -207,6 +207,7 @@ func (c *Client) orchestratePolling(until <-chan bool, getRefsOnInit <-chan bool
 				log.Info("stopping projects polling...")
 				return
 			case todo := <-getRefsOnInit:
+				log.Debugf("executing init pipeline? %v", todo)
 				if todo {
 					c.pollPipelinesOnInit()
 				}
@@ -239,7 +240,9 @@ func (c *Client) discoverWildcards() {
 }
 
 func (c *Client) pollPipelinesOnInit() {
+	log.Debug("Polling latest pipelines to get data out of them")
 	for _, p := range cfg.Projects {
+		log.Debug("On init: reading project %s",p.Name)
 		gitlabProject, err := c.getProject(p.Name)
 		if err != nil {
 			log.Errorf("could not get GitLab project with name %s: %v", p.Name, err)
@@ -303,7 +306,7 @@ func (c *Client) pollProjectsWith(numWorkers int, doing func(Project) error, unt
 }
 
 func (c *Client) pipelinesFor(gp *gitlab.Project, options *gitlab.ListProjectPipelinesOptions) ([]*gitlab.PipelineInfo, error) {
-	log.Debugf("Reading pipelines for project %v (%v)", gp.PathWithNamespace, gp.ID)
+	log.Debugf("Reading pipelines for project %v (ID %v)", gp.PathWithNamespace, gp.ID)
 	c.rateLimit()
 	pipelines, _, err := c.Pipelines.ListProjectPipelines(gp.ID, options)
 	if err != nil {

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -207,7 +207,7 @@ func (c *Client) orchestratePolling(until <-chan bool, getRefsOnInit <-chan bool
 				log.Info("stopping projects polling...")
 				return
 			case todo := <-getRefsOnInit:
-				log.Debugf("executing init pipeline? %v", todo)
+				log.Debugf("should we poll the more recent refs from the last executed pipelines? %v", todo)
 				if todo {
 					c.pollPipelinesOnInit()
 				}

--- a/cmd/gitlab_test.go
+++ b/cmd/gitlab_test.go
@@ -34,22 +34,23 @@ func getMockedGitlabClient() (*http.ServeMux, *httptest.Server, *Client) {
 
 // Functions testing
 func TestProjectExists(t *testing.T) {
-	foo := Project{Name: "foo"}
+	foo := Project{Name: "foo", Refs: "abc"}
+	fooClone := foo
 	bar := Project{Name: "bar"}
 
-	cfg = &Config{
+	config := &Config{
 		Projects: []Project{foo},
 	}
 
-	assert.Equal(t, true, projectExists(foo))
-	assert.Equal(t, false, projectExists(bar))
+	assert.Equal(t, true, projectExists(fooClone, config.Projects))
+	assert.Equal(t, false, projectExists(bar, config.Projects))
 }
 
 func TestRefExists(t *testing.T) {
 	refs := []string{"foo"}
 
-	assert.Equal(t, true, refExists(refs, "foo"))
-	assert.Equal(t, false, refExists(refs, "bar"))
+	assert.Equal(t, true, refExists("foo", refs))
+	assert.Equal(t, false, refExists("bar", refs))
 }
 
 func TestGetProject(t *testing.T) {

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -153,7 +153,7 @@ func emitStatusMetric(metric *prometheus.GaugeVec, labelValues []string, statuse
 
 type pipelineVarsFetchOp func(interface{}, int, ...gitlab.RequestOptionFunc) ([]*gitlab.PipelineVariable, *gitlab.Response, error)
 
-func emitPipelineVariablesMetric(c *Client, metric *prometheus.GaugeVec, projectName, ref string, projectID, pipelineID int, fetch pipelineVarsFetchOp, filterRegexp *regexp.Regexp) error {
+func emitPipelineVariablesMetric(c *Client, gauge *prometheus.GaugeVec, projectName, ref string, projectID, pipelineID int, fetch pipelineVarsFetchOp, filterRegexp *regexp.Regexp) error {
 	// get the pipelines data from API
 	c.rateLimit()
 	variables, _, err := fetch(projectID, pipelineID)
@@ -168,7 +168,7 @@ func emitPipelineVariablesMetric(c *Client, metric *prometheus.GaugeVec, project
 				varValues = append(varValues, v.Key)
 			}
 		}
-		metric.WithLabelValues(projectName, ref, strings.Join(varValues, ",")).Inc()
+		gauge.WithLabelValues(projectName, ref, strings.Join(varValues, ",")).Inc()
 	}
 	return nil
 }

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -152,7 +153,8 @@ func emitStatusMetric(metric *prometheus.GaugeVec, labelValues []string, statuse
 
 type pipelineVarsFetchOp func(interface{}, int, ...gitlab.RequestOptionFunc) ([]*gitlab.PipelineVariable, *gitlab.Response, error)
 
-func emitPipelineVariablesMetric(c *Client, metric *prometheus.GaugeVec, projectName, ref string, projectID int, pipelineID int, fetch pipelineVarsFetchOp) error {
+func emitPipelineVariablesMetric(c *Client, metric *prometheus.GaugeVec, projectName, ref string, projectID, pipelineID int, fetch pipelineVarsFetchOp, filterRegexp *regexp.Regexp) error {
+	// get the pipelines data from API
 	c.rateLimit()
 	variables, _, err := fetch(projectID, pipelineID)
 	if err != nil {
@@ -161,7 +163,10 @@ func emitPipelineVariablesMetric(c *Client, metric *prometheus.GaugeVec, project
 	if len(variables) > 0 {
 		var varValues []string
 		for _, v := range variables {
-			varValues = append(varValues, v.Key)
+			// only add the variables whose key matches the regex
+			if filterRegexp.MatchString(v.Key) {
+				varValues = append(varValues, v.Key)
+			}
 		}
 		metric.WithLabelValues(projectName, ref, strings.Join(varValues, ",")).Inc()
 	}

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -58,8 +58,8 @@ var (
 		[]string{"project", "topics", "ref", "stage", "job_name"},
 	)
 
-	jobRunCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	jobRunCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Name: "gitlab_ci_pipeline_job_run_count",
 			Help: "GitLab CI pipeline job run count",
 		},
@@ -82,8 +82,8 @@ var (
 		[]string{"project", "topics", "ref", "status"},
 	)
 
-	runCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	runCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Name: "gitlab_ci_pipeline_run_count",
 			Help: "GitLab CI pipeline run count",
 		},
@@ -103,7 +103,7 @@ var (
 			Name: "gitlab_ci_pipeline_run_count_with_variable",
 			Help: "Count of pipelines with variables",
 		},
-		[]string{"project", "ref", "pipeline_variables"},
+		[]string{"project", "topics", "ref", "pipeline_variables"},
 	)
 )
 
@@ -153,7 +153,7 @@ func emitStatusMetric(metric *prometheus.GaugeVec, labelValues []string, statuse
 
 type pipelineVarsFetchOp func(interface{}, int, ...gitlab.RequestOptionFunc) ([]*gitlab.PipelineVariable, *gitlab.Response, error)
 
-func emitPipelineVariablesMetric(c *Client, gauge *prometheus.GaugeVec, projectName, ref string, projectID, pipelineID int, fetch pipelineVarsFetchOp, filterRegexp *regexp.Regexp) error {
+func emitPipelineVariablesMetric(c *Client, gauge *prometheus.GaugeVec, projectName, topics, ref string, projectID, pipelineID int, fetch pipelineVarsFetchOp, filterRegexp *regexp.Regexp) error {
 	// get the pipelines data from API
 	c.rateLimit()
 	variables, _, err := fetch(projectID, pipelineID)
@@ -168,7 +168,7 @@ func emitPipelineVariablesMetric(c *Client, gauge *prometheus.GaugeVec, projectN
 				varValues = append(varValues, v.Key)
 			}
 		}
-		gauge.WithLabelValues(projectName, ref, strings.Join(varValues, ",")).Inc()
+		gauge.WithLabelValues(projectName, topics, ref, strings.Join(varValues, ",")).Inc()
 	}
 	return nil
 }

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 	"github.com/xanzy/go-gitlab"
 )
 

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -132,12 +132,12 @@ func registerMetricOn(registry *prometheus.Registry, metrics ...prometheus.Colle
 	}
 }
 
-func emitStatusMetric(metric *prometheus.GaugeVec, labelValuess []string, statuses []string, status string, sparseMetrics bool) {
+func emitStatusMetric(metric *prometheus.GaugeVec, labelValues []string, statuses []string, status string, sparseMetrics bool) {
 	// Moved into separate function to reduce cyclomatic complexity
 	// List of available statuses from the API spec
 	// ref: https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs
 	for _, s := range statuses {
-		args := append(labelValuess, s)
+		args := append(labelValues, s)
 		if s == status {
 			metric.WithLabelValues(args...).Set(1)
 		} else {

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -153,10 +153,10 @@ func emitStatusMetric(metric *prometheus.GaugeVec, labelValues []string, statuse
 
 type pipelineVarsFetchOp func(interface{}, int, ...gitlab.RequestOptionFunc) ([]*gitlab.PipelineVariable, *gitlab.Response, error)
 
-func emitPipelineVariablesMetric(c *Client, gauge *prometheus.GaugeVec, projectName, topics, ref string, projectID, pipelineID int, fetch pipelineVarsFetchOp, filterRegexp *regexp.Regexp) error {
+func emitPipelineVariablesMetric(c *Client, gauge *prometheus.GaugeVec, details *projectDetails, pipelineID int, fetch pipelineVarsFetchOp, filterRegexp *regexp.Regexp) error {
 	// get the pipelines data from API
 	c.rateLimit()
-	variables, _, err := fetch(projectID, pipelineID)
+	variables, _, err := fetch(details.pID, pipelineID)
 	if err != nil {
 		return fmt.Errorf("could not fetch pipeline variables for pipeline %d: %s", pipelineID, err.Error())
 	}
@@ -168,7 +168,7 @@ func emitPipelineVariablesMetric(c *Client, gauge *prometheus.GaugeVec, projectN
 				varValues = append(varValues, v.Key)
 			}
 		}
-		gauge.WithLabelValues(projectName, topics, ref, strings.Join(varValues, ",")).Inc()
+		gauge.WithLabelValues(augmentLabelValues(details, strings.Join(varValues, ","))...).Inc()
 	}
 	return nil
 }

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
-	log "github.com/sirupsen/logrus"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -125,12 +124,11 @@ var (
 	}
 )
 
-func registerMetricOn(registry *prometheus.Registry, log *log.Logger, metrics ...prometheus.Collector) {
+func registerMetricOn(registry *prometheus.Registry, metrics ...prometheus.Collector) {
 	for _, m := range metrics {
-		//if err := registry.Register(m); err != nil {
-		//	log.Fatalf("could not add provided metric '%v' to the Prometheus registry: %v", m, err)
-		//}
-		registry.MustRegister(m)
+		if err := registry.Register(m); err != nil {
+			panic(fmt.Errorf("could not add provided metric '%v' to the Prometheus registry: %v", m, err))
+		}
 	}
 }
 

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+	"github.com/xanzy/go-gitlab"
+)
+
+var (
+	coverage = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gitlab_ci_pipeline_coverage",
+			Help: "Coverage of the most recent pipeline",
+		},
+		[]string{"project", "topics", "ref"},
+	)
+
+	lastRunDuration = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gitlab_ci_pipeline_last_run_duration_seconds",
+			Help: "Duration of last pipeline run",
+		},
+		[]string{"project", "topics", "ref"},
+	)
+
+	lastRunJobDuration = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gitlab_ci_pipeline_last_job_run_duration_seconds",
+			Help: "Duration of last job run",
+		},
+		[]string{"project", "topics", "ref", "stage", "job_name"},
+	)
+
+	lastRunJobStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gitlab_ci_pipeline_last_job_run_status",
+			Help: "Status of the most recent job",
+		},
+		[]string{"project", "topics", "ref", "stage", "job_name", "status"},
+	)
+
+	lastRunJobArtifactSize = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gitlab_ci_pipeline_last_job_run_artifact_size",
+			Help: "Filesize of the most recent job artifacts",
+		},
+		[]string{"project", "topics", "ref", "stage", "job_name"},
+	)
+
+	timeSinceLastJobRun = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gitlab_ci_pipeline_time_since_last_job_run_seconds",
+			Help: "Elapsed time since most recent GitLab CI job run.",
+		},
+		[]string{"project", "topics", "ref", "stage", "job_name"},
+	)
+
+	jobRunCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gitlab_ci_pipeline_job_run_count",
+			Help: "GitLab CI pipeline job run count",
+		},
+		[]string{"project", "topics", "ref", "stage", "job_name"},
+	)
+
+	lastRunID = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gitlab_ci_pipeline_last_run_id",
+			Help: "ID of the most recent pipeline",
+		},
+		[]string{"project", "topics", "ref"},
+	)
+
+	lastRunStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gitlab_ci_pipeline_last_run_status",
+			Help: "Status of the most recent pipeline",
+		},
+		[]string{"project", "topics", "ref", "status"},
+	)
+
+	runCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gitlab_ci_pipeline_run_count",
+			Help: "GitLab CI pipeline run count",
+		},
+		[]string{"project", "topics", "ref"},
+	)
+
+	timeSinceLastRun = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gitlab_ci_pipeline_time_since_last_run_seconds",
+			Help: "Elapsed time since most recent GitLab CI pipeline run.",
+		},
+		[]string{"project", "topics", "ref"},
+	)
+)
+
+var (
+	registry       = prometheus.NewRegistry()
+	defaultMetrics = []prometheus.Collector{coverage, lastRunDuration, lastRunID, lastRunStatus, runCount, timeSinceLastJobRun, lastRunDuration, lastRunJobStatus, jobRunCount, timeSinceLastJobRun, lastRunJobArtifactSize}
+)
+
+func registerMetricOn(registry *prometheus.Registry, log *log.Logger, metrics ...prometheus.Collector) {
+	for _, m := range metrics {
+		if err := registry.Register(m); err != nil {
+			log.Fatalf("could not add provided metric '%v' to the Prometheus registry: %v", m, err)
+		}
+	}
+}
+
+func emitStatusMetric(metric *prometheus.GaugeVec, labels []string, statuses []string, status string, sparseMetrics bool) {
+	// Moved into separate function to reduce cyclomatic complexity
+	// List of available statuses from the API spec
+	// ref: https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs
+	for _, s := range statuses {
+		args := append(labels, s)
+		if s == status {
+			metric.WithLabelValues(args...).Set(1)
+		} else {
+			if sparseMetrics {
+				metric.DeleteLabelValues(args...)
+			} else {
+				metric.WithLabelValues(args...).Set(0)
+			}
+		}
+	}
+}
+
+func variableLabelledCounter(vars []gitlab.PipelineVariable) prometheus.Counter {
+	var labels []string
+	for _, v := range vars {
+		labels = append(labels, v.Key)
+	}
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_vars"}, labels).WithLabelValues(labels...)
+	counter.Add(1.0)
+	return counter
+}

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 
@@ -168,7 +169,11 @@ func emitPipelineVariablesMetric(c *Client, gauge *prometheus.GaugeVec, details 
 				varValues = append(varValues, v.Key)
 			}
 		}
-		gauge.WithLabelValues(augmentLabelValues(details, strings.Join(varValues, ","))...).Inc()
+		// only create the metric if there are matching vars
+		if len(varValues) > 0 {
+			log.Debugf("creating metric for pipelines with variables: %v", varValues)
+			gauge.WithLabelValues(augmentLabelValues(details, strings.Join(varValues, ","))...).Inc()
+		}
 	}
 	return nil
 }

--- a/cmd/metrics_test.go
+++ b/cmd/metrics_test.go
@@ -85,9 +85,10 @@ func TestEmitFilteredVariablesMetric(t *testing.T) {
 		assert.NoError(t,
 			emitPipelineVariablesMetric(client, counter, details, 0, testOkFetchFn, rx))
 
-		g, err := counter.GetMetricWithLabelValues("test", "tag", "test-project", "master")
+		g, err := counter.GetMetricWithLabelValues("test", "tag", "master", "test-project")
 		assert.NoError(t, err)
 		assert.NotNil(t, g.Desc())
+		assert.Contains(t, g.Desc().String(), "pipeline_variables")
 
 		g2, err := counter.GetMetricWith(prometheus.Labels{"pipeline_variables": "test-2"})
 		assert.Error(t, err)

--- a/cmd/metrics_test.go
+++ b/cmd/metrics_test.go
@@ -54,11 +54,21 @@ func TestEmitVariablesMetric(t *testing.T) {
 		RateLimiter: ratelimit.New(2),
 	}
 	rx, err := regexp.Compile(variablesCatchallRegex)
+	details := &projectDetails{"test-project", "tag", "master", 0}
 	if assert.Nil(t, err) {
 		assert.NoError(t,
-			emitPipelineVariablesMetric(client, variableLabelledCounter("gitlab_ci_pipeline_run_count_with_variable", []string{"project", "topics", "ref", "pipeline_variables"}), "test-project", "tag", "master", 0, 0, testOkFetchFn, rx))
+			emitPipelineVariablesMetric(client,
+				variableLabelledCounter("gitlab_ci_pipeline_run_count_with_variable", []string{"project", "topics", "ref", "pipeline_variables"}),
+				details, 0,
+				testOkFetchFn,
+				rx))
 		assert.Error(t,
-			emitPipelineVariablesMetric(client, variableLabelledCounter("gitlab_ci_pipeline_run_count_with_variable", []string{"project", "topics", "ref", "pipeline_variables"}), "test-project", "tag", "master", 0, 0, testErrFetchFn, rx))
+			emitPipelineVariablesMetric(client,
+				variableLabelledCounter("gitlab_ci_pipeline_run_count_with_variable", []string{"project", "topics", "ref", "pipeline_variables"}),
+				details,
+				0,
+				testErrFetchFn,
+				rx))
 	}
 }
 
@@ -68,9 +78,12 @@ func TestEmitFilteredVariablesMetric(t *testing.T) {
 	}
 	counter := variableLabelledCounter("gitlab_ci_pipeline_run_count_with_variable", []string{"project", "topics", "ref", "pipeline_variables"})
 	rx, err := regexp.Compile(`^test$`)
+
+	details := &projectDetails{"test-project", "tag", "master", 0}
+
 	if assert.Nil(t, err) {
 		assert.NoError(t,
-			emitPipelineVariablesMetric(client, counter, "test-project", "test-tag", "master", 0, 0, testOkFetchFn, rx))
+			emitPipelineVariablesMetric(client, counter, details, 0, testOkFetchFn, rx))
 
 		g, err := counter.GetMetricWithLabelValues("test", "tag", "test-project", "master")
 		assert.NoError(t, err)

--- a/cmd/metrics_test.go
+++ b/cmd/metrics_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/xanzy/go-gitlab"
+	"go.uber.org/ratelimit"
 )
 
 // introduce a test to check the /metrics endpoint body
@@ -26,6 +28,22 @@ func TestMetricsRegistryContainsMetricsWhenSet(t *testing.T) {
 	assert.Contains(t, w.Body.String(), some)
 }
 
+// introduce a test to check the /metrics endpoint body
+func TestMetricsRegistryFailsWhenDouble(t *testing.T) {
+	// a custom additional metric added to the registry
+	some := "test_something"
+	aCounter := prometheus.NewCounter(prometheus.CounterOpts{Name: some})
+	reg := prometheus.NewRegistry()
+	registerMetricOn(reg, nil, aCounter)
+	registerMetricOn(reg, nil, aCounter)
+	defer func(){
+		if r := recover(); r!=nil {
+			t.Log("failed correctly")
+		}
+	}()
+}
+
+
 func TestAMetricCanBeAddedLabelDynamically(t *testing.T) {
 	// a custom additional metric added to the registry
 	counter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_something"}, []string{"first", "second"})
@@ -37,12 +55,21 @@ func TestAMetricCanBeAddedLabelDynamically(t *testing.T) {
 	}
 }
 
-func TestAVariableConstMetricIsUpdated(t *testing.T) {
-	someVars := []gitlab.PipelineVariable{{Key: "test", Value: "testval"}, {Key: "test-2", Value: "aaaa", VariableType: "env_var"}}
+func TestEmitVariablesMetric(t *testing.T) {
+	var testOkFetchFn = func(interface{}, int, ...gitlab.RequestOptionFunc) ([]*gitlab.PipelineVariable, *gitlab.Response, error) {
+		return []*gitlab.PipelineVariable{{Key: "test", Value: "testval"}, {Key: "test-2", Value: "aaaa", VariableType: "env_var"}}, nil, nil
+	}
+	var testErrFetchFn = func(interface{}, int, ...gitlab.RequestOptionFunc) ([]*gitlab.PipelineVariable, *gitlab.Response, error) {
+		return nil, nil, fmt.Errorf("some error")
+	}
+	client := &Client{
+		RateLimiter: ratelimit.New(2),
+	}
 
-	counter := variableLabelledCounter(someVars)
-	assert.Contains(t, counter.Desc().String(), "test")
-	assert.Contains(t, counter.Desc().String(), "test-2")
-	assert.NotContains(t, counter.Desc().String(), "testval")
-
+	assert.NoError(t,
+		emitPipelineVariablesMetric(client, variableLabelledCounter("gitlab_ci_pipeline_run_count_with_variable", []string{"project", "ref", "pipeline_variables"}),
+			"test-project", "master", 0, 0, testOkFetchFn))
+	assert.Error(t,
+		emitPipelineVariablesMetric(client, variableLabelledCounter("gitlab_ci_pipeline_run_count_with_variable", []string{"project", "ref", "pipeline_variables"}),
+			"test-project", "master", 0, 0, testErrFetchFn))
 }

--- a/cmd/metrics_test.go
+++ b/cmd/metrics_test.go
@@ -18,7 +18,7 @@ func TestMetricsRegistryContainsMetricsWhenSet(t *testing.T) {
 	some := "test_something"
 	aCounter := prometheus.NewCounter(prometheus.CounterOpts{Name: some})
 	reg := prometheus.NewRegistry()
-	registerMetricOn(reg, nil, aCounter)
+	registerMetricOn(reg, aCounter)
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -34,15 +34,12 @@ func TestMetricsRegistryFailsWhenDouble(t *testing.T) {
 	some := "test_something"
 	aCounter := prometheus.NewCounter(prometheus.CounterOpts{Name: some})
 	reg := prometheus.NewRegistry()
-	registerMetricOn(reg, nil, aCounter)
-	registerMetricOn(reg, nil, aCounter)
-	defer func(){
-		if r := recover(); r!=nil {
-			t.Log("failed correctly")
-		}
-	}()
+	registerMetricOn(reg, aCounter)
+	panicFn := func() {
+		registerMetricOn(reg, aCounter)
+	}
+	assert.Panics(t, panicFn)
 }
-
 
 func TestAMetricCanBeAddedLabelDynamically(t *testing.T) {
 	// a custom additional metric added to the registry

--- a/cmd/metrics_test.go
+++ b/cmd/metrics_test.go
@@ -56,9 +56,9 @@ func TestEmitVariablesMetric(t *testing.T) {
 	rx, err := regexp.Compile(variablesCatchallRegex)
 	if assert.Nil(t, err) {
 		assert.NoError(t,
-			emitPipelineVariablesMetric(client, variableLabelledCounter("gitlab_ci_pipeline_run_count_with_variable", []string{"project", "ref", "pipeline_variables"}), "test-project", "master", 0, 0, testOkFetchFn, rx))
+			emitPipelineVariablesMetric(client, variableLabelledCounter("gitlab_ci_pipeline_run_count_with_variable", []string{"project", "topics", "ref", "pipeline_variables"}), "test-project", "tag", "master", 0, 0, testOkFetchFn, rx))
 		assert.Error(t,
-			emitPipelineVariablesMetric(client, variableLabelledCounter("gitlab_ci_pipeline_run_count_with_variable", []string{"project", "ref", "pipeline_variables"}), "test-project", "master", 0, 0, testErrFetchFn, rx))
+			emitPipelineVariablesMetric(client, variableLabelledCounter("gitlab_ci_pipeline_run_count_with_variable", []string{"project", "topics", "ref", "pipeline_variables"}), "test-project", "tag", "master", 0, 0, testErrFetchFn, rx))
 	}
 }
 
@@ -66,13 +66,13 @@ func TestEmitFilteredVariablesMetric(t *testing.T) {
 	client := &Client{
 		RateLimiter: ratelimit.New(2),
 	}
-	counter := variableLabelledCounter("gitlab_ci_pipeline_run_count_with_variable", []string{"project", "ref", "pipeline_variables"})
+	counter := variableLabelledCounter("gitlab_ci_pipeline_run_count_with_variable", []string{"project", "topics", "ref", "pipeline_variables"})
 	rx, err := regexp.Compile(`^test$`)
 	if assert.Nil(t, err) {
 		assert.NoError(t,
-			emitPipelineVariablesMetric(client, counter, "test-project", "master", 0, 0, testOkFetchFn, rx))
+			emitPipelineVariablesMetric(client, counter, "test-project", "test-tag", "master", 0, 0, testOkFetchFn, rx))
 
-		g, err := counter.GetMetricWithLabelValues("test", "test-project", "master")
+		g, err := counter.GetMetricWithLabelValues("test", "tag", "test-project", "master")
 		assert.NoError(t, err)
 		assert.NotNil(t, g.Desc())
 

--- a/cmd/metrics_test.go
+++ b/cmd/metrics_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/xanzy/go-gitlab"
+)
+
+// introduce a test to check the /metrics endpoint body
+func TestMetricsRegistryContainsMetricsWhenSet(t *testing.T) {
+	// a custom additional metric added to the registry
+	some := "test_something"
+	aCounter := prometheus.NewCounter(prometheus.CounterOpts{Name: some})
+	reg := prometheus.NewRegistry()
+	registerMetricOn(reg, nil, aCounter)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	metricsHandlerFor(reg, false).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+	assert.Contains(t, w.Body.String(), some)
+}
+
+func TestAMetricCanBeAddedLabelDynamically(t *testing.T) {
+	// a custom additional metric added to the registry
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_something"}, []string{"first", "second"})
+	prometheus.MustRegister(counter)
+
+	curriedCounter, err := counter.CurryWith(prometheus.Labels{"first": "0", "second": "something"})
+	if assert.Nil(t, err) {
+		assert.Contains(t, curriedCounter.WithLabelValues().Desc().String(), "something")
+	}
+}
+
+func TestAVariableConstMetricIsUpdated(t *testing.T) {
+	someVars := []gitlab.PipelineVariable{{Key: "test", Value: "testval"}, {Key: "test-2", Value: "aaaa", VariableType: "env_var"}}
+
+	counter := variableLabelledCounter(someVars)
+	assert.Contains(t, counter.Desc().String(), "test")
+	assert.Contains(t, counter.Desc().String(), "test-2")
+	assert.NotContains(t, counter.Desc().String(), "testval")
+
+}


### PR DESCRIPTION
Hello,

here a draft of adding pipeline variables inside metrics.
The PR contains a pretty big refactoring for 2 areas:
* initial project polling
* metrics registration

One thing that I'd like to tackle is how to simplify the gauges increment when polling the projects: right now for my understanding of the codebase we are not able to discern if a counter for a project should be incremented every time we process it, because we should fetch the previous value?
You can see this in `emitPipelineVariablesMetric` function: when the first time it runs, it will set a value for the parsed jobs with variables. How could it know the second time it runs that a previous metric has been already set? Does prometheus lib handle that?