### PR TITLE
Use chart v1 version to support helm 2

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,4 +2,4 @@ name: gitlab-ci-pipelines-exporter
 version: 0.3.1
 appVersion: 0.3.1
 description: Prometheus / OpenMetrics exporter for GitLab CI pipelines insights
-apiVersion: v2
+apiVersion: v1


### PR DESCRIPTION
Hello there 👋 , First of all, thanks for this repo, it has been useful for me.

Now, I had an issue trying to integrate with a Cluster using Helm 2. Using Chart version 2 is only usable by Helm 3, while version 1 is compatible with both Helm 2 and Helm 3.

I believe this won't break anything for people using Helm 3. Thanks!