### PR TITLE
FIX selector

### DIFF
--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -15,9 +15,10 @@ metadata:
   {{- end }}
 spec:
   selector:
-    app.kubernetes.io/name: {{ include "app.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/from: deploy.{{ include "app.fullname" . }}
+    matchLabels:
+      app.kubernetes.io/name: {{ include "app.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      helm.sh/from: deploy.{{ include "app.fullname" . }}
   endpoints:
     - port: metrics
       interval: {{ .Values.serviceMonitor.scrapeInterval }}


### PR DESCRIPTION
Need to add `matchLabels`, without it doesn't work.
https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#labelselector-v1-meta
There is an error when try to install.
`error validating data: [ValidationError(ServiceMonitor.spec.selector): unknown field "app.kubernetes.io/instance" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector, ValidationError(ServiceMonitor.spec.selector): unknown field "app.kubernetes.io/name" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector, ValidationError(ServiceMonitor.spec.selector): unknown field "helm.sh/from" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector]
`