### PR TITLE
Allow 'main' and 'master' as default ref regex detection

### DIFF
--- a/docs/configuration_syntax.md
+++ b/docs/configuration_syntax.md
@@ -79,8 +79,8 @@ defaults:
   pipeline_variables_filter_regexp: ".*"
 
   # Filter refs (branches/tags) to include
-  # (optional, default: "^master$" -- master branch)
-  refs_regexp: "^master$"
+  # (optional, default: "^main|master$" -- main or master branch)
+  refs_regexp: "^main|master$"
 
   # Fetch merge request pipelines refs (optional, default: false)
   fetch_merge_request_pipelines_refs: false
@@ -113,8 +113,8 @@ projects:
     pipeline_variables_filter_regexp: ".*"
 
     # Filter refs (branches/tags) to include
-    # (optional, default: "^master$" -- master branch)
-    refs_regexp: "^master$"
+    # (optional, default: "^main|master$" -- main or master branch)
+    refs_regexp: "^main|master$"
 
     # Fetch merge request pipelines refs (optional, default: false)
     fetch_merge_request_pipelines_refs: false
@@ -167,8 +167,8 @@ wildcards:
     pipeline_variables_filter_regexp: ".*"
 
     # Filter refs (branches/tags) to include
-    # (optional, default: "^master$" -- master branch)
-    refs_regexp: "^master$"
+    # (optional, default: "^main|master$" -- main or master branch)
+    refs_regexp: "^main|master$"
 
     # Fetch merge request pipelines refs (optional, default: false)
     fetch_merge_request_pipelines_refs: false

--- a/example/grafana/dashboard.json
+++ b/example/grafana/dashboard.json
@@ -739,9 +739,9 @@
         "allValue": "",
         "current": {
           "selected": true,
-          "text": "master",
+          "text": "All",
           "value": [
-            "master"
+            "$__all"
           ]
         },
         "datasource": null,

--- a/lib/schemas/config_test.go
+++ b/lib/schemas/config_test.go
@@ -74,12 +74,14 @@ projects:
   - name: foo/project
   - name: bar/project
     refs_regexp: "^master|dev$"
+  - name: new/project
+    refs_regexp: "^main|dev$"
 
 wildcards:
   - owner:
       name: foo
       kind: group
-    refs_regexp: "^master|1.0$"
+    refs_regexp: "^main|master|1.0$"
     search: 'bar'
     archived: true
 `)
@@ -130,6 +132,12 @@ wildcards:
 					RefsRegexpValue: pointy.String("^master|dev$"),
 				},
 			},
+			{
+				Name: "new/project",
+				Parameters: Parameters{
+					RefsRegexpValue: pointy.String("^main|dev$"),
+				},
+			},
 		},
 		Wildcards: []Wildcard{
 			{
@@ -143,7 +151,7 @@ wildcards:
 					Kind: "group",
 				},
 				Parameters: Parameters{
-					RefsRegexpValue: pointy.String("^master|1.0$"),
+					RefsRegexpValue: pointy.String("^main|master|1.0$"),
 				},
 				Archived: true,
 			},
@@ -215,7 +223,7 @@ disable_openmetrics_encoding: true
 projects:
   - name: foo/project
   - name: bar/project
-    refs_regexp: "^master|dev$"
+    refs_regexp: "^main|master|dev$"
 `)
 
 	config := &Config{}
@@ -233,7 +241,7 @@ func TestParseConfigWithoutPollingWorkersUsesGOMAXPROCS(t *testing.T) {
 projects:
   - name: foo/project
   - name: bar/project
-    refs_regexp: "^master|dev$"
+    refs_regexp: "^main|master|dev$"
 `)
 	config := &Config{}
 	assert.NoError(t, config.Parse(f.Name()))
@@ -253,7 +261,7 @@ defaults:
 projects:
   - name: foo/project
   - name: bar/project
-    refs_regexp: "^master|dev$"
+    refs_regexp: "^main|master|dev$"
 `)
 	cfg := &Config{}
 	assert.NoError(t, cfg.Parse(f.Name()))

--- a/lib/schemas/project.go
+++ b/lib/schemas/project.go
@@ -28,7 +28,7 @@ const (
 	defaultFetchPipelineJobMetrics              = false
 	defaultOutputSparseStatusMetrics            = false
 	defaultFetchPipelineVariables               = false
-	defaultRefsRegexp                           = `^master$`
+	defaultRefsRegexp                           = `^(main|master)$`
 	defaultPipelineVariablesRegexp              = `.*`
 	defaultFetchMergeRequestsPipelinesRefs      = false
 	defaultFetchMergeRequestsPipelinesRefsLimit = 1


### PR DESCRIPTION
I've been trying the great demo and then inspected the Docker container because it did not detect my project. Then I figured that the auto-discovery works with default branch names, and my project uses `main`.

I have patched the default regex and adopted the tests. This PR also contains an update for the Grafana dashboard to show all refs by default, not just master. 

Test details: https://gitlab.com/gitlab-org/gitlab/-/issues/4854#note_395683247 