### PR TITLE
use bind mount in docker-compose quickstart

### DIFF
--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -10,7 +10,9 @@ services:
     environment:
       GCPE_CONFIG: /etc/gitlab-ci-pipelines-exporter/config.yml
     volumes:
-      - ./gitlab-ci-pipelines-exporter/config.yml:/etc/gitlab-ci-pipelines-exporter/config.yml
+      - type: bind
+        source: ./gitlab-ci-pipelines-exporter
+        target: /etc/gitlab-ci-pipelines-exporter
 
   prometheus:
     image: prom/prometheus:v2.21.0


### PR DESCRIPTION
Fixes issue with Docker Compose in which the exporter container would fail to restart because the `config.yml` file already existed.

```
$ docker-compose up -d

    # Works fine the first time

$ vim gitlab-ci-pipelines-exporter/config.yml  # Change config                                                                                                                                                                               

$ docker-compose restart
Restarting quickstart_grafana_1                      ... done
Restarting quickstart_prometheus_1                   ... done
Restarting quickstart_gitlab-ci-pipelines-exporter_1 ... error

ERROR: for quickstart_gitlab-ci-pipelines-exporter_1  Cannot restart container d688967c9d3190e01319ca4aac27ae35b9c457c3dfaac653ae331d68f4dc552d: error while creating mount source path '/host_mnt/Users/[redacted]/gitlab-ci-
pipelines-exporter/examples/quickstart/gitlab-ci-pipelines-exporter/config.yml': mkdir /host_mnt/Users/[redacted]/gitlab-ci-pipelines-exporter/examples/quickstart/gitlab-ci-pipelines-exporter/config.yml: file exists
```

Was using MacOS 10.15.6 with docker versions:

```
$ docker version
Client: Docker Engine - Community
 Cloud integration  0.1.18
 Version:           19.03.13
 API version:       1.40
 Go version:        go1.13.15
 Git commit:        4484c46d9d
 Built:             Wed Sep 16 16:58:31 2020
 OS/Arch:           darwin/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          19.03.13
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.13.15
  Git commit:       4484c46d9d
  Built:            Wed Sep 16 17:07:04 2020
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.3.7
  GitCommit:        8fba4e9a7d01810a393d5d25a3621dc101981175
 runc:
  Version:          1.0.0-rc10
  GitCommit:        dc9208a3303feef5b3839f4323d9beb36df0a9dd
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683
```

But this change shouldn't affect users too much. It will mount the gitlab-ci-pipelines-exporter inside the container with a bind mount.

Please let me know if you have any questions

Thanks