### PR TITLE
make runners description available as label for jobs

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,12 +15,12 @@
 | `gitlab_ci_pipeline_coverage` | Coverage of the most recent pipeline | [project], [topics], [ref], [kind], [variables] | *available by default* |
 | `gitlab_ci_pipeline_duration_seconds` | Duration in seconds of the most recent pipeline | [project], [topics], [ref], [kind], [variables] | *available by default* |
 | `gitlab_ci_pipeline_id` | ID of the most recent pipeline | [project], [topics], [ref], [kind], [variables] | *available by default* |
-| `gitlab_ci_pipeline_job_artifact_size_bytes` | Artifact size in bytes (sum of all of them) of the most recent job | [project], [topics], [ref], [kind], [variables], [stage], [job_name] | `project_defaults.pull.pipeline.jobs.enabled` |
-| `gitlab_ci_pipeline_job_duration_seconds` | Duration in seconds of the most recent job | [project], [topics], [ref], [kind], [variables], [stage], [job_name] | `project_defaults.pull.pipeline.jobs.enabled` |
-| `gitlab_ci_pipeline_job_id` | ID of the most recent job | [project], [topics], [ref], [kind], [variables], [stage], [job_name] | `project_defaults.pull.pipeline.jobs.enabled` |
-| `gitlab_ci_pipeline_job_run_count` | Number of executions of a job | [project], [topics], [ref], [kind], [variables], [stage], [job_name] | `project_defaults.pull.pipeline.jobs.enabled` |
-| `gitlab_ci_pipeline_job_status` | Status of the most recent job | [project], [topics], [ref], [kind], [variables], [stage], [job_name], [status] | `project_defaults.pull.pipeline.jobs.enabled` |
-| `gitlab_ci_pipeline_job_timestamp` | Creation date timestamp of the the most recent job | [project], [topics], [ref], [kind], [variables], [stage], [job_name] | `project_defaults.pull.pipeline.jobs.enabled` |
+| `gitlab_ci_pipeline_job_artifact_size_bytes` | Artifact size in bytes (sum of all of them) of the most recent job | [project], [topics], [ref], [runner], [kind], [variables], [stage], [job_name] | `project_defaults.pull.pipeline.jobs.enabled` |
+| `gitlab_ci_pipeline_job_duration_seconds` | Duration in seconds of the most recent job | [project], [topics], [ref], [runner], [kind], [variables], [stage], [job_name] | `project_defaults.pull.pipeline.jobs.enabled` |
+| `gitlab_ci_pipeline_job_id` | ID of the most recent job | [project], [topics], [ref], [runner], [kind], [variables], [stage], [job_name] | `project_defaults.pull.pipeline.jobs.enabled` |
+| `gitlab_ci_pipeline_job_run_count` | Number of executions of a job | [project], [topics], [ref], [runner], [kind], [variables], [stage], [job_name] | `project_defaults.pull.pipeline.jobs.enabled` |
+| `gitlab_ci_pipeline_job_status` | Status of the most recent job | [project], [topics], [ref], [runner], [kind], [variables], [stage], [job_name], [status] | `project_defaults.pull.pipeline.jobs.enabled` |
+| `gitlab_ci_pipeline_job_timestamp` | Creation date timestamp of the the most recent job | [project], [topics], [ref], [runner], [kind], [variables], [stage], [job_name] | `project_defaults.pull.pipeline.jobs.enabled` |
 | `gitlab_ci_pipeline_status` | Status of the most recent pipeline | [project], [topics], [ref], [kind], [variables], [status] | *available by default* |
 | `gitlab_ci_pipeline_timestamp` | Timestamp of the last update of the most recent pipeline | [project], [topics], [ref], [kind], [variables] | *available by default* |
 | `gitlab_ci_pipeline_run_count` | Number of executions of a pipeline | [project], [topics], [ref], [kind], [variables] | *available by default* |
@@ -38,6 +38,10 @@ Topics configured on the project
 ### Ref Name
 
 Name of the ref (branch, tag or merge request) used by the pipeline
+
+### Runner
+
+Description of the runner
 
 ### Ref Kind
 
@@ -127,3 +131,4 @@ This flag affect every `_status$` metrics:
 [status]: #status
 [topics]: #topics
 [variables]: #variables
+[runner]: #runner

--- a/pkg/exporter/collectors.go
+++ b/pkg/exporter/collectors.go
@@ -4,7 +4,7 @@ import "github.com/prometheus/client_golang/prometheus"
 
 var (
 	defaultLabels                = []string{"project", "topics", "kind", "ref", "variables"}
-	jobLabels                    = []string{"stage", "job_name"}
+	jobLabels                    = []string{"stage", "job_name", "runner"}
 	statusLabels                 = []string{"status"}
 	statusesList                 = [...]string{"created", "waiting_for_resource", "preparing", "pending", "running", "success", "failed", "canceled", "skipped", "manual", "scheduled"}
 	environmentLabels            = []string{"project", "environment"}

--- a/pkg/exporter/jobs.go
+++ b/pkg/exporter/jobs.go
@@ -51,6 +51,7 @@ func processJobMetrics(ref schemas.Ref, job schemas.Job) {
 	labels := ref.DefaultLabelsValues()
 	labels["stage"] = job.Stage
 	labels["job_name"] = job.Name
+	labels["runner"] = job.Runner
 
 	projectRefLogFields := log.Fields{
 		"project-name": ref.ProjectName,

--- a/pkg/exporter/jobs_test.go
+++ b/pkg/exporter/jobs_test.go
@@ -79,6 +79,7 @@ func TestProcessJobMetrics(t *testing.T) {
 		Status:          "failed",
 		Stage:           "🚀",
 		ArtifactSize:    150,
+		Runner:          "xxx",
 	}
 
 	ref := schemas.Ref{
@@ -122,6 +123,7 @@ func TestProcessJobMetrics(t *testing.T) {
 		"variables": ref.LatestPipeline.Variables,
 		"stage":     newJob.Stage,
 		"job_name":  newJob.Name,
+		"runner":    newJob.Runner,
 	}
 
 	lastJobRunID := schemas.Metric{

--- a/pkg/schemas/jobs.go
+++ b/pkg/schemas/jobs.go
@@ -9,6 +9,7 @@ type Job struct {
 	ID              int
 	Name            string
 	Stage           string
+	Runner          string
 	Timestamp       float64
 	DurationSeconds float64
 	Status          string
@@ -34,6 +35,7 @@ func NewJob(gj goGitlab.Job) Job {
 		ID:              gj.ID,
 		Name:            gj.Name,
 		Stage:           gj.Stage,
+		Runner:          gj.Runner.Description,
 		Timestamp:       timestamp,
 		DurationSeconds: gj.Duration,
 		Status:          gj.Status,

--- a/pkg/schemas/jobs_test.go
+++ b/pkg/schemas/jobs_test.go
@@ -17,6 +17,15 @@ func TestNewJob(t *testing.T) {
 		Duration:  15,
 		Status:    "failed",
 		Stage:     "🚀",
+		Runner: struct {
+			ID          int    "json:\"id\""
+			Description string "json:\"description\""
+			Active      bool   "json:\"active\""
+			IsShared    bool   "json:\"is_shared\""
+			Name        string "json:\"name\""
+		}{
+			Description: "xxx",
+		},
 		Artifacts: []struct {
 			FileType   string "json:\"file_type\""
 			Filename   string "json:\"filename\""
@@ -39,6 +48,7 @@ func TestNewJob(t *testing.T) {
 		Timestamp:       1.601557505e+09,
 		DurationSeconds: 15,
 		Status:          "failed",
+		Runner:          "xxx",
 		ArtifactSize:    150,
 	}
 


### PR DESCRIPTION
As I was eager to have this feature myself, to monitor a little better the runner usage (see, how the weighting actually works between different runners) I made this.

The value is empty for jobs that have never run.

I wouldn't consider myself a Go expert, please add any thoughts on this! 

Should close #126 

**Edit:** Also should do some documentation, will do that with another commit tomorrow!