### PR TITLE
+ make owner-selector apply to projects + graphs

### DIFF
--- a/examples/quickstart/grafana/dashboards/dashboard_pipelines.json
+++ b/examples/quickstart/grafana/dashboards/dashboard_pipelines.json
@@ -1485,7 +1485,7 @@
         "name": "OWNER",
         "options": [],
         "query": "label_values(gitlab_ci_pipeline_id, project)",
-        "refresh": 2,
+        "refresh": 1,
         "regex": "/(.*)\\/.*$/",
         "skipUrlSync": false,
         "sort": 0,
@@ -1496,7 +1496,7 @@
         "useTags": false
       },
       {
-        "allValue": ".*",
+        "allValue": "",
         "current": {
           "selected": true,
           "text": [
@@ -1516,7 +1516,7 @@
         "name": "PROJECT",
         "options": [],
         "query": "label_values(gitlab_ci_pipeline_id{project=~\"$OWNER.*\"}, project)",
-        "refresh": 2,
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
@@ -1547,7 +1547,7 @@
         "name": "REF",
         "options": [],
         "query": "label_values(gitlab_ci_pipeline_id{project=~\"$PROJECT\"}, ref)",
-        "refresh": 2,
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,


### PR DESCRIPTION
Previously selecting:
- owner: a + b +c 
- project: All
had no effect on the shown graphs/tables, only on the selectabl project values.
Switching the project `custom_all` value to `auto`, the owner-filter actually applies directly to the project-var, selecting project-`all` shows all graphs from the selected owner.
