### PR TITLE
Pipeline queued duration

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -14,6 +14,7 @@
 | `gitlab_ci_environment_information` | Information about the environment | [project], [environment], [environment_id], [external_url], [kind], [ref], [latest_commit_short_id], [current_commit_short_id], [available], [username] | `project_defaults.pull.environments.enabled` |
 | `gitlab_ci_pipeline_coverage` | Coverage of the most recent pipeline | [project], [topics], [ref], [kind], [variables] | *available by default* |
 | `gitlab_ci_pipeline_duration_seconds` | Duration in seconds of the most recent pipeline | [project], [topics], [ref], [kind], [variables] | *available by default* |
+| `gitlab_ci_pipeline_queued_duration_seconds` | Duration in seconds the most recent pipeline has been queued before starting | [project], [topics], [ref], [kind], [variables] | *available by default* |
 | `gitlab_ci_pipeline_id` | ID of the most recent pipeline | [project], [topics], [ref], [kind], [variables] | *available by default* |
 | `gitlab_ci_pipeline_job_artifact_size_bytes` | Artifact size in bytes (sum of all of them) of the most recent job | [project], [topics], [ref], [runner_description], [kind], [variables], [stage], [job_name] | `project_defaults.pull.pipeline.jobs.enabled` |
 | `gitlab_ci_pipeline_job_duration_seconds` | Duration in seconds of the most recent job | [project], [topics], [ref], [runner_description], [kind], [variables], [stage], [job_name] | `project_defaults.pull.pipeline.jobs.enabled` |

--- a/examples/webhooks/README.md
+++ b/examples/webhooks/README.md
@@ -104,6 +104,7 @@ If you query the `/metrics` endpoint of the exporter you should be able to see a
 ```shell
 gitlab_ci_pipeline_coverage{kind="branch",project="foo/bar",ref="main",topics="",variables=""} 0
 gitlab_ci_pipeline_duration_seconds{kind="branch",project="foo/bar",ref="main",topics="",variables=""} 494
+gitlab_ci_pipeline_queued_duration_seconds{kind="branch",project="foo/bar",ref="main",topics="",variables=""} 60
 gitlab_ci_pipeline_id{kind="branch",project="foo/bar",ref="main",topics="",variables=""} 1.00308162e+08
 gitlab_ci_pipeline_run_count{kind="branch",project="foo/bar",ref="main",topics="",variables=""} 0
 gitlab_ci_pipeline_status{kind="branch",project="foo/bar",ref="main",status="canceled",topics="",variables=""} 0

--- a/pkg/exporter/collectors.go
+++ b/pkg/exporter/collectors.go
@@ -33,6 +33,17 @@ func NewCollectorDurationSeconds() prometheus.Collector {
 	)
 }
 
+// NewCollectorQueuedDurationSeconds returns a new collector for the gitlab_ci_pipeline_queued_duration_seconds metric
+func NewCollectorQueuedDurationSeconds() prometheus.Collector {
+	return prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gitlab_ci_pipeline_queued_duration_seconds",
+			Help: "Duration in seconds the most recent pipeline has been queued",
+		},
+		defaultLabels,
+	)
+}
+
 // NewCollectorEnvironmentBehindCommitsCount returns a new collector for the gitlab_ci_environment_behind_commits_count metric
 func NewCollectorEnvironmentBehindCommitsCount() prometheus.Collector {
 	return prometheus.NewGaugeVec(

--- a/pkg/exporter/collectors.go
+++ b/pkg/exporter/collectors.go
@@ -38,7 +38,7 @@ func NewCollectorQueuedDurationSeconds() prometheus.Collector {
 	return prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "gitlab_ci_pipeline_queued_duration_seconds",
-			Help: "Duration in seconds the most recent pipeline has been queued",
+			Help: "Duration in seconds the most recent pipeline has been queued before starting",
 		},
 		defaultLabels,
 	)

--- a/pkg/exporter/collectors_test.go
+++ b/pkg/exporter/collectors_test.go
@@ -11,6 +11,7 @@ func TestNewCollectorFunctions(t *testing.T) {
 	for _, f := range [](func() prometheus.Collector){
 		NewCollectorCoverage,
 		NewCollectorDurationSeconds,
+		NewCollectorQueuedDurationSeconds,
 		NewCollectorEnvironmentBehindCommitsCount,
 		NewCollectorEnvironmentBehindDurationSeconds,
 		NewCollectorEnvironmentDeploymentDurationSeconds,

--- a/pkg/exporter/metrics.go
+++ b/pkg/exporter/metrics.go
@@ -28,6 +28,7 @@ func NewRegistry() *Registry {
 		Collectors: RegistryCollectors{
 			schemas.MetricKindCoverage:                             NewCollectorCoverage(),
 			schemas.MetricKindDurationSeconds:                      NewCollectorDurationSeconds(),
+			schemas.MetricKindQueuedDurationSeconds:                NewCollectorQueuedDurationSeconds(),
 			schemas.MetricKindEnvironmentBehindCommitsCount:        NewCollectorEnvironmentBehindCommitsCount(),
 			schemas.MetricKindEnvironmentBehindDurationSeconds:     NewCollectorEnvironmentBehindDurationSeconds(),
 			schemas.MetricKindEnvironmentDeploymentCount:           NewCollectorEnvironmentDeploymentCount(),

--- a/pkg/exporter/pipelines.go
+++ b/pkg/exporter/pipelines.go
@@ -115,6 +115,12 @@ func pullRefMetrics(ref schemas.Ref) error {
 		})
 
 		storeSetMetric(schemas.Metric{
+			Kind:   schemas.MetricKindQueuedDurationSeconds,
+			Labels: ref.DefaultLabelsValues(),
+			Value:  pipeline.QueuedDurationSeconds,
+		})
+
+		storeSetMetric(schemas.Metric{
 			Kind:   schemas.MetricKindTimestamp,
 			Labels: ref.DefaultLabelsValues(),
 			Value:  pipeline.Timestamp,

--- a/pkg/exporter/pipelines_test.go
+++ b/pkg/exporter/pipelines_test.go
@@ -70,6 +70,13 @@ func TestPullRefMetricsSucceed(t *testing.T) {
 	}
 	assert.Equal(t, runID, metrics[runID.Key()])
 
+	queued := schemas.Metric{
+		Kind:   schemas.MetricKindQueuedDurationSeconds,
+		Labels: labels,
+		Value:  60,
+	}
+	assert.Equal(t, queued, metrics[queued.Key()])
+
 	labels["status"] = "running"
 	status := schemas.Metric{
 		Kind:   schemas.MetricKindStatus,
@@ -78,12 +85,6 @@ func TestPullRefMetricsSucceed(t *testing.T) {
 	}
 	assert.Equal(t, status, metrics[status.Key()])
 
-	queued := schemas.Metric{
-		Kind:   schemas.MetricKindQueuedDurationSeconds,
-		Labels: labels,
-		Value:  60,
-	}
-	assert.Equal(t, queued, metrics[queued.Key()])
 }
 
 func TestPullRefMetricsMergeRequestPipeline(t *testing.T) {

--- a/pkg/exporter/pipelines_test.go
+++ b/pkg/exporter/pipelines_test.go
@@ -84,7 +84,6 @@ func TestPullRefMetricsSucceed(t *testing.T) {
 		Value:  1,
 	}
 	assert.Equal(t, status, metrics[status.Key()])
-
 }
 
 func TestPullRefMetricsMergeRequestPipeline(t *testing.T) {

--- a/pkg/exporter/pipelines_test.go
+++ b/pkg/exporter/pipelines_test.go
@@ -84,7 +84,6 @@ func TestPullRefMetricsSucceed(t *testing.T) {
 		Value:  60,
 	}
 	assert.Equal(t, queued, metrics[queued.Key()])
-
 }
 
 func TestPullRefMetricsMergeRequestPipeline(t *testing.T) {

--- a/pkg/exporter/pipelines_test.go
+++ b/pkg/exporter/pipelines_test.go
@@ -21,7 +21,8 @@ func TestPullRefMetricsSucceed(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/projects/foo/pipelines/1",
 		func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprint(w, `{"id":1,"updated_at":"2016-08-11T11:28:34.085Z","duration":300,"status":"running","coverage":"30.2"}`)
+			fmt.Fprint(w, `{"id":1,"created_at":"2016-08-11T11:27:00.085Z", "started_at":"2016-08-11T11:28:00.085Z",
+			"updated_at":"2016-08-11T11:28:34.085Z","duration":300,"status":"running","coverage":"30.2"}`)
 		})
 
 	mux.HandleFunc(fmt.Sprintf("/api/v4/projects/foo/pipelines/1/variables"),
@@ -76,6 +77,14 @@ func TestPullRefMetricsSucceed(t *testing.T) {
 		Value:  1,
 	}
 	assert.Equal(t, status, metrics[status.Key()])
+
+	queued := schemas.Metric{
+		Kind:   schemas.MetricKindQueuedDurationSeconds,
+		Labels: labels,
+		Value:  60,
+	}
+	assert.Equal(t, queued, metrics[queued.Key()])
+
 }
 
 func TestPullRefMetricsMergeRequestPipeline(t *testing.T) {

--- a/pkg/schemas/metric.go
+++ b/pkg/schemas/metric.go
@@ -15,6 +15,9 @@ const (
 	// MetricKindDurationSeconds ..
 	MetricKindDurationSeconds
 
+	// MetricKindQueuedDurationSeconds ..
+	MetricKindQueuedDurationSeconds
+
 	// MetricKindEnvironmentBehindCommitsCount ..
 	MetricKindEnvironmentBehindCommitsCount
 
@@ -91,7 +94,7 @@ func (m Metric) Key() MetricKey {
 	key := strconv.Itoa(int(m.Kind))
 
 	switch m.Kind {
-	case MetricKindCoverage, MetricKindDurationSeconds, MetricKindID, MetricKindStatus, MetricKindRunCount, MetricKindTimestamp:
+	case MetricKindCoverage, MetricKindDurationSeconds, MetricKindQueuedDurationSeconds, MetricKindID, MetricKindStatus, MetricKindRunCount, MetricKindTimestamp:
 		key += fmt.Sprintf("%v", []string{
 			m.Labels["project"],
 			m.Labels["kind"],

--- a/pkg/schemas/metric_test.go
+++ b/pkg/schemas/metric_test.go
@@ -15,7 +15,7 @@ func TestMetricKey(t *testing.T) {
 		},
 	}.Key())
 
-	assert.Equal(t, MetricKey("77312310"), Metric{
+	assert.Equal(t, MetricKey("2573719482"), Metric{
 		Kind: MetricKindEnvironmentInformation,
 		Labels: prometheus.Labels{
 			"project":     "foo",
@@ -24,7 +24,7 @@ func TestMetricKey(t *testing.T) {
 		},
 	}.Key())
 
-	assert.Equal(t, MetricKey("77312310"), Metric{
+	assert.Equal(t, MetricKey("2573719482"), Metric{
 		Kind: MetricKindEnvironmentInformation,
 		Labels: prometheus.Labels{
 			"project":     "foo",
@@ -33,7 +33,7 @@ func TestMetricKey(t *testing.T) {
 		},
 	}.Key())
 
-	assert.Equal(t, MetricKey("1288741005"), Metric{
+	assert.Equal(t, MetricKey("1258247728"), Metric{
 		Kind: MetricKindEnvironmentInformation,
 	}.Key())
 }

--- a/pkg/schemas/pipelines.go
+++ b/pkg/schemas/pipelines.go
@@ -37,7 +37,9 @@ func NewPipeline(gp goGitlab.Pipeline) Pipeline {
 
 	var queued float64
 	if gp.StartedAt != nil && gp.CreatedAt != nil {
-		queued = float64(gp.CreatedAt.Sub(*gp.StartedAt) * time.Second)
+		if gp.CreatedAt.Before(*gp.StartedAt) {
+			queued = float64(gp.CreatedAt.Sub(*gp.StartedAt) * time.Second)
+		}
 	}
 
 	return Pipeline{

--- a/pkg/schemas/pipelines.go
+++ b/pkg/schemas/pipelines.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"strconv"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	goGitlab "github.com/xanzy/go-gitlab"
@@ -9,12 +10,13 @@ import (
 
 // Pipeline ..
 type Pipeline struct {
-	ID              int
-	Coverage        float64
-	Timestamp       float64
-	DurationSeconds float64
-	Status          string
-	Variables       string
+	ID                    int
+	Coverage              float64
+	Timestamp             float64
+	DurationSeconds       float64
+	QueuedDurationSeconds float64
+	Status                string
+	Variables             string
 }
 
 // NewPipeline ..
@@ -33,11 +35,17 @@ func NewPipeline(gp goGitlab.Pipeline) Pipeline {
 		timestamp = float64(gp.UpdatedAt.Unix())
 	}
 
+	var queued float64
+	if gp.StartedAt != nil && gp.CreatedAt != nil {
+		queued = float64(gp.CreatedAt.Sub(*gp.StartedAt) * time.Second)
+	}
+
 	return Pipeline{
-		ID:              gp.ID,
-		Coverage:        coverage,
-		Timestamp:       timestamp,
-		DurationSeconds: float64(gp.Duration),
-		Status:          gp.Status,
+		ID:                    gp.ID,
+		Coverage:              coverage,
+		Timestamp:             timestamp,
+		DurationSeconds:       float64(gp.Duration),
+		QueuedDurationSeconds: queued,
+		Status:                gp.Status,
 	}
 }

--- a/pkg/schemas/pipelines.go
+++ b/pkg/schemas/pipelines.go
@@ -35,10 +35,10 @@ func NewPipeline(gp goGitlab.Pipeline) Pipeline {
 		timestamp = float64(gp.UpdatedAt.Unix())
 	}
 
-	var queued float64
+	var queued time.Duration
 	if gp.StartedAt != nil && gp.CreatedAt != nil {
 		if gp.CreatedAt.Before(*gp.StartedAt) {
-			queued = float64(gp.CreatedAt.Sub(*gp.StartedAt) * time.Second)
+			queued = gp.StartedAt.Sub(*gp.CreatedAt)
 		}
 	}
 
@@ -47,7 +47,7 @@ func NewPipeline(gp goGitlab.Pipeline) Pipeline {
 		Coverage:              coverage,
 		Timestamp:             timestamp,
 		DurationSeconds:       float64(gp.Duration),
-		QueuedDurationSeconds: queued,
+		QueuedDurationSeconds: queued.Seconds(),
 		Status:                gp.Status,
 	}
 }

--- a/pkg/schemas/pipelines_test.go
+++ b/pkg/schemas/pipelines_test.go
@@ -29,3 +29,30 @@ func TestNewPipeline(t *testing.T) {
 
 	assert.Equal(t, expectedPipeline, NewPipeline(gitlabPipeline))
 }
+
+func TestRunningPipeline(t *testing.T) {
+	createdAt := time.Date(2020, 10, 1, 13, 4, 10, 0, time.UTC)
+	startedAt := time.Date(2020, 10, 1, 13, 5, 10, 0, time.UTC)
+	updatedAt := time.Date(2020, 10, 1, 13, 5, 10, 0, time.UTC)
+
+	gitlabPipeline := goGitlab.Pipeline{
+		ID:        21,
+		Coverage:  "25.6",
+		CreatedAt: &createdAt,
+		StartedAt: &startedAt,
+		UpdatedAt: &updatedAt,
+		Duration:  15,
+		Status:    "running",
+	}
+
+	expectedPipeline := Pipeline{
+		ID:                    21,
+		Coverage:              25.6,
+		Timestamp:             1.60155751e+09,
+		DurationSeconds:       15,
+		QueuedDurationSeconds: 60,
+		Status:                "running",
+	}
+
+	assert.Equal(t, expectedPipeline, NewPipeline(gitlabPipeline))
+}


### PR DESCRIPTION
Should fixe issue #272 by adding queued duration for pipelines.

In GitLab 13.12, it seems this will be exposed as queued_duration field, and this will be calculated as `started_at - created_at`: https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/ci/pipeline.rb#L851

Use same logic