### PR TITLE
Fix example quickstart docker images tag

### DIFF
--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ./prometheus/config.yml:/etc/prometheus/prometheus.yml
 
   grafana:
-    image: docker.io/grafana/grafana:7.5
+    image: docker.io/grafana/grafana:7.5.0
     ports:
       - 3000:3000
     environment:

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         target: /etc/gitlab-ci-pipelines-exporter.yml
 
   prometheus:
-    image: docker.io/prom/prometheus:v2.27
+    image: docker.io/prom/prometheus:v2.27.0
     ports:
       - 9090:9090
     links:


### PR DESCRIPTION
This should resolve these issues
![image](https://user-images.githubusercontent.com/22779039/121801602-60972b80-cc4d-11eb-85a5-b7bb59e9fe96.png)
![image](https://user-images.githubusercontent.com/22779039/121801611-68ef6680-cc4d-11eb-97b1-8a68c71e1c05.png)
After running `docker-compose up -d` in examples/quickstart