### PR TITLE
fix: pagination without a x-total-pages header #339

### DIFF
--- a/pkg/gitlab/branches.go
+++ b/pkg/gitlab/branches.go
@@ -43,7 +43,7 @@ func (c *Client) GetProjectBranches(p schemas.Project) (
 			}
 		}
 
-		if resp.CurrentPage >= resp.TotalPages {
+		if resp.CurrentPage >= resp.NextPage {
 			break
 		}
 		options.Page = resp.NextPage

--- a/pkg/gitlab/branches_test.go
+++ b/pkg/gitlab/branches_test.go
@@ -20,10 +20,13 @@ func TestGetProjectBranches(t *testing.T) {
 			assert.Equal(t, []string{"100"}, r.URL.Query()["per_page"])
 			currentPage, err := strconv.Atoi(r.URL.Query()["page"][0])
 			assert.NoError(t, err)
+			nextPage := currentPage + 1
+			if currentPage == 2 {
+				nextPage = currentPage
+			}
 
-			w.Header().Add("X-Total-Pages", "2")
 			w.Header().Add("X-Page", strconv.Itoa(currentPage))
-			w.Header().Add("X-Next-Page", strconv.Itoa(currentPage+1))
+			w.Header().Add("X-Next-Page", strconv.Itoa(nextPage))
 
 			if currentPage == 1 {
 				fmt.Fprint(w, `[{"name":"main"},{"name":"dev"}]`)

--- a/pkg/gitlab/environments.go
+++ b/pkg/gitlab/environments.go
@@ -57,7 +57,7 @@ func (c *Client) GetProjectEnvironments(p schemas.Project) (
 			}
 		}
 
-		if resp.CurrentPage >= resp.TotalPages {
+		if resp.CurrentPage >= resp.NextPage {
 			break
 		}
 		options.Page = resp.NextPage

--- a/pkg/gitlab/environments_test.go
+++ b/pkg/gitlab/environments_test.go
@@ -20,10 +20,13 @@ func TestGetProjectEnvironments(t *testing.T) {
 			assert.Equal(t, []string{"100"}, r.URL.Query()["per_page"])
 			currentPage, err := strconv.Atoi(r.URL.Query()["page"][0])
 			assert.NoError(t, err)
+			nextPage := currentPage + 1
+			if currentPage == 2 {
+				nextPage = currentPage
+			}
 
-			w.Header().Add("X-Total-Pages", "2")
 			w.Header().Add("X-Page", strconv.Itoa(currentPage))
-			w.Header().Add("X-Next-Page", strconv.Itoa(currentPage+1))
+			w.Header().Add("X-Next-Page", strconv.Itoa(nextPage))
 
 			if scope, ok := r.URL.Query()["states"]; ok && len(scope) == 1 && scope[0] == "available" {
 				fmt.Fprint(w, `[{"id":1338,"name":"main"}]`)

--- a/pkg/gitlab/jobs.go
+++ b/pkg/gitlab/jobs.go
@@ -61,7 +61,7 @@ func (c *Client) ListPipelineJobs(projectName string, pipelineID int) (jobs []sc
 			jobs = append(jobs, schemas.NewJob(*job))
 		}
 
-		if resp.CurrentPage >= resp.TotalPages {
+		if resp.CurrentPage >= resp.NextPage {
 			log.WithFields(
 				log.Fields{
 					"project-name": projectName,
@@ -98,7 +98,7 @@ func (c *Client) ListPipelineBridges(projectName string, pipelineID int) (bridge
 
 		bridges = append(bridges, foundBridges...)
 
-		if resp.CurrentPage >= resp.TotalPages {
+		if resp.CurrentPage >= resp.NextPage {
 			log.WithFields(
 				log.Fields{
 					"project-name":  projectName,
@@ -208,7 +208,7 @@ func (c *Client) ListRefMostRecentJobs(ref schemas.Ref) (jobs []schemas.Job, err
 			}
 		}
 
-		if resp.CurrentPage >= resp.TotalPages {
+		if resp.CurrentPage >= resp.NextPage {
 			var notFoundJobs []string
 			for k := range jobsToRefresh {
 				notFoundJobs = append(notFoundJobs, k)

--- a/pkg/gitlab/pipelines.go
+++ b/pkg/gitlab/pipelines.go
@@ -215,7 +215,7 @@ func (c *Client) GetRefsFromPipelines(p schemas.Project, refKind schemas.RefKind
 			}
 		}
 
-		if resp.CurrentPage >= resp.TotalPages {
+		if resp.CurrentPage >= resp.NextPage {
 			break
 		}
 		options.Page = resp.NextPage

--- a/pkg/gitlab/projects.go
+++ b/pkg/gitlab/projects.go
@@ -116,7 +116,7 @@ func (c *Client) ListProjects(w config.Wildcard) ([]schemas.Project, error) {
 			projects = append(projects, p)
 		}
 
-		if resp.CurrentPage >= resp.TotalPages {
+		if resp.CurrentPage >= resp.NextPage {
 			break
 		}
 

--- a/pkg/gitlab/tags.go
+++ b/pkg/gitlab/tags.go
@@ -42,7 +42,7 @@ func (c *Client) GetProjectTags(p schemas.Project) (
 			}
 		}
 
-		if resp.CurrentPage >= resp.TotalPages {
+		if resp.CurrentPage >= resp.NextPage {
 			break
 		}
 		options.Page = resp.NextPage
@@ -78,7 +78,7 @@ func (c *Client) GetProjectMostRecentTagCommit(projectName, filterRegexp string)
 			}
 		}
 
-		if resp.CurrentPage >= resp.TotalPages {
+		if resp.CurrentPage >= resp.NextPage {
 			break
 		}
 		options.Page = resp.NextPage


### PR DESCRIPTION
according to https://docs.gitlab.com/ee/user/gitlab_com/index.html#pagination-response-headers the x-total-pages header might be missing