### PR TITLE
WebhookHandler: Fix invalid JSON typo in error message

### DIFF
--- a/pkg/controller/handlers.go
+++ b/pkg/controller/handlers.go
@@ -57,7 +57,7 @@ func (c *Controller) WebhookHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Header.Get("X-Gitlab-Token") != c.Config.Server.Webhook.SecretToken {
 		log.WithFields(logFields).Debug("invalid token provided for a webhook request")
 		w.WriteHeader(http.StatusForbidden)
-		fmt.Fprint(w, "{\"error\": \"invalid token\"")
+		fmt.Fprint(w, "{\"error\": \"invalid token\"}")
 		return
 	}
 


### PR DESCRIPTION
Discovered when setting up a webhook-based configuration locally.

(We could add a newline `\n` there also if you don't mind? More readable if you `curl` if that way.)