### PR TITLE
Grafana: Fix commit sha truncated

### DIFF
--- a/examples/quickstart/grafana/dashboards/dashboard_environments.json
+++ b/examples/quickstart/grafana/dashboards/dashboard_environments.json
@@ -1283,6 +1283,10 @@
                     "url": "https://${GITLAB_HOST}/${__data.fields.Project:raw}/-/commit/${__value.text}"
                   }
                 ]
+              },
+              {
+                "id": "unit",
+                "value": "string"
               }
             ]
           },


### PR DESCRIPTION
If commit sha is like 04416854 it is interpreted as numeric and then the zero is removed. This leads to incomplete links to Gitlab