### PR TITLE
[doc] configuration_syntax.md: fix misplaced line

### DIFF
--- a/docs/configuration_syntax.md
+++ b/docs/configuration_syntax.md
@@ -20,13 +20,13 @@ server:
   listen_address: :8080
   
   # Enable profiling pages
+  # at /debug/pprof (optional, default: false)
   enable_pprof: false
   
   metrics:
     # Enable /metrics endpoint (optional, default: true)
     enabled: true
-  # at /debug/pprof (optional, default: false)
-
+  
     # Enable OpenMetrics content encoding in
     # prometheus HTTP handler (optional, default: false)
     # see: https://godoc.org/github.com/prometheus/client_golang/prometheus/promhttp#HandlerOpts


### PR DESCRIPTION
Reverting a glitch in the doc introduced in bf9144508c77c714ce73bf1d770128604397af7f