### PR TITLE
Add id and status labels to pipeline and job metrics

### DIFF
--- a/pkg/controller/collectors.go
+++ b/pkg/controller/collectors.go
@@ -4,7 +4,8 @@ import "github.com/prometheus/client_golang/prometheus"
 
 var (
 	defaultLabels                = []string{"project", "topics", "kind", "ref", "variables"}
-	jobLabels                    = []string{"stage", "job_name", "runner_description"}
+	jobLabels                    = []string{"stage", "job_name", "runner_description", "pipeline_id", "job_id"}
+	pipelineLabels               = []string{"pipeline_id"}
 	statusLabels                 = []string{"status"}
 	environmentLabels            = []string{"project", "environment"}
 	environmentInformationLabels = []string{"environment_id", "external_url", "kind", "ref", "latest_commit_short_id", "current_commit_short_id", "available", "username"}
@@ -117,7 +118,7 @@ func NewCollectorCoverage() prometheus.Collector {
 			Name: "gitlab_ci_pipeline_coverage",
 			Help: "Coverage of the most recent pipeline",
 		},
-		defaultLabels,
+		append(defaultLabels, pipelineLabels...),
 	)
 }
 
@@ -128,7 +129,7 @@ func NewCollectorDurationSeconds() prometheus.Collector {
 			Name: "gitlab_ci_pipeline_duration_seconds",
 			Help: "Duration in seconds of the most recent pipeline",
 		},
-		defaultLabels,
+		append(defaultLabels, pipelineLabels...),
 	)
 }
 
@@ -139,7 +140,7 @@ func NewCollectorQueuedDurationSeconds() prometheus.Collector {
 			Name: "gitlab_ci_pipeline_queued_duration_seconds",
 			Help: "Duration in seconds the most recent pipeline has been queued before starting",
 		},
-		defaultLabels,
+		append(defaultLabels, pipelineLabels...),
 	)
 }
 
@@ -238,7 +239,7 @@ func NewCollectorID() prometheus.Collector {
 			Name: "gitlab_ci_pipeline_id",
 			Help: "ID of the most recent pipeline",
 		},
-		defaultLabels,
+		append(defaultLabels, pipelineLabels...),
 	)
 }
 
@@ -326,7 +327,7 @@ func NewCollectorStatus() prometheus.Collector {
 			Name: "gitlab_ci_pipeline_status",
 			Help: "Status of the most recent pipeline",
 		},
-		append(defaultLabels, "status"),
+		append(defaultLabels, append(pipelineLabels, statusLabels...)...),
 	)
 }
 
@@ -337,7 +338,7 @@ func NewCollectorTimestamp() prometheus.Collector {
 			Name: "gitlab_ci_pipeline_timestamp",
 			Help: "Timestamp of the last update of the most recent pipeline",
 		},
-		defaultLabels,
+		append(defaultLabels, pipelineLabels...),
 	)
 }
 
@@ -348,6 +349,6 @@ func NewCollectorRunCount() prometheus.Collector {
 			Name: "gitlab_ci_pipeline_run_count",
 			Help: "Number of executions of a pipeline",
 		},
-		defaultLabels,
+		append(defaultLabels, pipelineLabels...),
 	)
 }

--- a/pkg/controller/collectors.go
+++ b/pkg/controller/collectors.go
@@ -4,8 +4,8 @@ import "github.com/prometheus/client_golang/prometheus"
 
 var (
 	defaultLabels                = []string{"project", "topics", "kind", "ref", "variables"}
-	jobLabels                    = []string{"stage", "job_name", "runner_description", "pipeline_id", "job_id"}
-	pipelineLabels               = []string{"pipeline_id"}
+	jobLabels                    = []string{"stage", "job_name", "runner_description", "pipeline_id", "job_id", "status"}
+	pipelineLabels               = []string{"pipeline_id", "status"}
 	statusLabels                 = []string{"status"}
 	environmentLabels            = []string{"project", "environment"}
 	environmentInformationLabels = []string{"environment_id", "external_url", "kind", "ref", "latest_commit_short_id", "current_commit_short_id", "available", "username"}
@@ -305,7 +305,7 @@ func NewCollectorJobStatus() prometheus.Collector {
 			Name: "gitlab_ci_pipeline_job_status",
 			Help: "Status of the most recent job",
 		},
-		append(defaultLabels, append(jobLabels, statusLabels...)...),
+		append(defaultLabels, jobLabels...),
 	)
 }
 
@@ -327,7 +327,7 @@ func NewCollectorStatus() prometheus.Collector {
 			Name: "gitlab_ci_pipeline_status",
 			Help: "Status of the most recent pipeline",
 		},
-		append(defaultLabels, append(pipelineLabels, statusLabels...)...),
+		append(defaultLabels, pipelineLabels...),
 	)
 }
 

--- a/pkg/controller/jobs.go
+++ b/pkg/controller/jobs.go
@@ -53,6 +53,7 @@ func (c *Controller) ProcessJobMetrics(ctx context.Context, ref schemas.Ref, job
 	labels := ref.DefaultLabelsValues()
 	labels["stage"] = job.Stage
 	labels["job_name"] = job.Name
+	labels["status"] = job.Status
 	labels["job_id"] = strconv.Itoa(job.ID)
 	labels["pipeline_id"] = strconv.Itoa(job.PipelineID)
 

--- a/pkg/controller/jobs.go
+++ b/pkg/controller/jobs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"regexp"
+	"strconv"
 
 	"github.com/mvisonneau/gitlab-ci-pipelines-exporter/pkg/schemas"
 	log "github.com/sirupsen/logrus"
@@ -52,6 +53,8 @@ func (c *Controller) ProcessJobMetrics(ctx context.Context, ref schemas.Ref, job
 	labels := ref.DefaultLabelsValues()
 	labels["stage"] = job.Stage
 	labels["job_name"] = job.Name
+	labels["job_id"] = strconv.Itoa(job.ID)
+	labels["pipeline_id"] = strconv.Itoa(job.PipelineID)
 
 	if ref.Project.Pull.Pipeline.Jobs.RunnerDescription.Enabled {
 		re, err := regexp.Compile(ref.Project.Pull.Pipeline.Jobs.RunnerDescription.AggregationRegexp)

--- a/pkg/controller/pipelines.go
+++ b/pkg/controller/pipelines.go
@@ -75,6 +75,7 @@ func (c *Controller) PullRefMetrics(ctx context.Context, ref schemas.Ref) error 
 
 		labels := ref.DefaultLabelsValues()
 		labels["pipeline_id"] = strconv.Itoa(pipeline.ID)
+		labels["status"] = pipeline.Status
 
 		// If the metric does not exist yet, start with 0 instead of 1
 		// this could cause some false positives in prometheus

--- a/pkg/controller/pipelines.go
+++ b/pkg/controller/pipelines.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 
 	"github.com/mvisonneau/gitlab-ci-pipelines-exporter/pkg/schemas"
 	log "github.com/sirupsen/logrus"
@@ -72,12 +73,15 @@ func (c *Controller) PullRefMetrics(ctx context.Context, ref schemas.Ref) error 
 			return err
 		}
 
+		labels := ref.DefaultLabelsValues()
+		labels["pipeline_id"] = strconv.Itoa(pipeline.ID)
+
 		// If the metric does not exist yet, start with 0 instead of 1
 		// this could cause some false positives in prometheus
 		// when restarting the exporter otherwise
 		runCount := schemas.Metric{
 			Kind:   schemas.MetricKindRunCount,
-			Labels: ref.DefaultLabelsValues(),
+			Labels: labels,
 		}
 
 		storeGetMetric(ctx, c.Store, &runCount)
@@ -90,13 +94,13 @@ func (c *Controller) PullRefMetrics(ctx context.Context, ref schemas.Ref) error 
 
 		storeSetMetric(ctx, c.Store, schemas.Metric{
 			Kind:   schemas.MetricKindCoverage,
-			Labels: ref.DefaultLabelsValues(),
+			Labels: labels,
 			Value:  pipeline.Coverage,
 		})
 
 		storeSetMetric(ctx, c.Store, schemas.Metric{
 			Kind:   schemas.MetricKindID,
-			Labels: ref.DefaultLabelsValues(),
+			Labels: labels,
 			Value:  float64(pipeline.ID),
 		})
 
@@ -104,7 +108,7 @@ func (c *Controller) PullRefMetrics(ctx context.Context, ref schemas.Ref) error 
 			ctx,
 			c.Store,
 			schemas.MetricKindStatus,
-			ref.DefaultLabelsValues(),
+			labels,
 			statusesList[:],
 			pipeline.Status,
 			ref.Project.OutputSparseStatusMetrics,
@@ -112,19 +116,19 @@ func (c *Controller) PullRefMetrics(ctx context.Context, ref schemas.Ref) error 
 
 		storeSetMetric(ctx, c.Store, schemas.Metric{
 			Kind:   schemas.MetricKindDurationSeconds,
-			Labels: ref.DefaultLabelsValues(),
+			Labels: labels,
 			Value:  pipeline.DurationSeconds,
 		})
 
 		storeSetMetric(ctx, c.Store, schemas.Metric{
 			Kind:   schemas.MetricKindQueuedDurationSeconds,
-			Labels: ref.DefaultLabelsValues(),
+			Labels: labels,
 			Value:  pipeline.QueuedDurationSeconds,
 		})
 
 		storeSetMetric(ctx, c.Store, schemas.Metric{
 			Kind:   schemas.MetricKindTimestamp,
-			Labels: ref.DefaultLabelsValues(),
+			Labels: labels,
 			Value:  pipeline.Timestamp,
 		})
 

--- a/pkg/schemas/jobs.go
+++ b/pkg/schemas/jobs.go
@@ -7,6 +7,7 @@ import (
 // Job ..
 type Job struct {
 	ID                    int
+	PipelineID            int
 	Name                  string
 	Stage                 string
 	Timestamp             float64
@@ -42,6 +43,7 @@ func NewJob(gj goGitlab.Job) Job {
 
 	return Job{
 		ID:                    gj.ID,
+		PipelineID:            gj.Pipeline.ID,
 		Name:                  gj.Name,
 		Stage:                 gj.Stage,
 		Timestamp:             timestamp,


### PR DESCRIPTION
See details in [issue 453](https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/issues/453).
This can be helpful to better filter the queries and also to present more than the last pipeline/job in the dashboard.