### PR TITLE
Parse internal monitoring listener address only when it is passed

### DIFF
--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -77,7 +77,9 @@ func configure(ctx *cli.Context) (cfg config.Config, err error) {
 }
 
 func parseGlobalFlags(ctx *cli.Context) (cfg config.Global, err error) {
-	cfg.InternalMonitoringListenerAddress, err = url.Parse(ctx.String("internal-monitoring-listener-address"))
+	if listenerAddr := ctx.String("internal-monitoring-listener-address"); listenerAddr != "" {
+		cfg.InternalMonitoringListenerAddress, err = url.Parse(listenerAddr)
+	}
 
 	return
 }


### PR DESCRIPTION
Calling `(url.URL).Parse()` on an empty string results in a non-nil value. This negates the check for it being `nil` in the monitoring server package.

https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/blob/main/pkg/monitor/server/server.go#L49

Fixes: #454 