### PR TITLE
fix: change deprecated NewExitError to the Exit

### DIFF
--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -95,7 +95,7 @@ func exit(exitCode int, err error) cli.ExitCoder {
 		log.WithError(err).Error()
 	}
 
-	return cli.NewExitError("", exitCode)
+	return cli.Exit("", exitCode)
 }
 
 // ExecWrapper gracefully logs and exits our `run` functions.


### PR DESCRIPTION
As the doc suggests ( Deprecated: This function is a duplicate of Exit and will eventually be removed.)