### PR TITLE
fix: remove ctx from method

### DIFF
--- a/pkg/controller/handlers.go
+++ b/pkg/controller/handlers.go
@@ -124,9 +124,9 @@ func (c *Controller) WebhookHandler(w http.ResponseWriter, r *http.Request) {
 
 	switch event := event.(type) {
 	case *gitlab.PipelineEvent:
-		go c.processPipelineEvent(ctx, *event)
+		go c.processPipelineEvent( *event)
 	case *gitlab.DeploymentEvent:
-		go c.processDeploymentEvent(ctx, *event)
+		go c.processDeploymentEvent(*event)
 	default:
 		log.WithContext(ctx).
 			WithFields(logFields).

--- a/pkg/controller/webhooks.go
+++ b/pkg/controller/webhooks.go
@@ -14,11 +14,13 @@ import (
 	"github.com/mvisonneau/gitlab-ci-pipelines-exporter/pkg/schemas"
 )
 
-func (c *Controller) processPipelineEvent(ctx context.Context, e goGitlab.PipelineEvent) {
+func (c *Controller) processPipelineEvent( e goGitlab.PipelineEvent) {
 	var (
 		refKind schemas.RefKind
 		refName = e.ObjectAttributes.Ref
 	)
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
 
 	// TODO: Perhaps it would be nice to match upon the regexp to validate
 	// that it is actually a merge request ref
@@ -144,7 +146,9 @@ schedulePull:
 	c.ScheduleTask(context.TODO(), schemas.TaskTypePullRefMetrics, string(ref.Key()), ref)
 }
 
-func (c *Controller) processDeploymentEvent(ctx context.Context, e goGitlab.DeploymentEvent) {
+func (c *Controller) processDeploymentEvent( e goGitlab.DeploymentEvent) {
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
 	c.triggerEnvironmentMetricsPull(
 		ctx,
 		schemas.Environment{


### PR DESCRIPTION

Issue: 
Parent context breaks the go routines while running.