### PR TITLE
bugfix: remove ctx parameter from handler 

### DIFF
--- a/pkg/controller/handlers.go
+++ b/pkg/controller/handlers.go
@@ -124,9 +124,9 @@ func (c *Controller) WebhookHandler(w http.ResponseWriter, r *http.Request) {
 
 	switch event := event.(type) {
 	case *gitlab.PipelineEvent:
-		go c.processPipelineEvent(ctx, *event)
+		go c.processPipelineEvent(*event)
 	case *gitlab.DeploymentEvent:
-		go c.processDeploymentEvent(ctx, *event)
+		go c.processDeploymentEvent(*event)
 	default:
 		log.WithContext(ctx).
 			WithFields(logFields).

--- a/pkg/controller/webhooks.go
+++ b/pkg/controller/webhooks.go
@@ -14,11 +14,18 @@ import (
 	"github.com/mvisonneau/gitlab-ci-pipelines-exporter/pkg/schemas"
 )
 
-func (c *Controller) processPipelineEvent(ctx context.Context, e goGitlab.PipelineEvent) {
+func (c *Controller) processPipelineEvent(e goGitlab.PipelineEvent) {
+
+
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defet ctxCancel()
+
 	var (
 		refKind schemas.RefKind
 		refName = e.ObjectAttributes.Ref
 	)
+
+
 
 	// TODO: Perhaps it would be nice to match upon the regexp to validate
 	// that it is actually a merge request ref
@@ -144,7 +151,11 @@ schedulePull:
 	c.ScheduleTask(context.TODO(), schemas.TaskTypePullRefMetrics, string(ref.Key()), ref)
 }
 
-func (c *Controller) processDeploymentEvent(ctx context.Context, e goGitlab.DeploymentEvent) {
+func (c *Controller) processDeploymentEvent(e goGitlab.DeploymentEvent) {
+
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defet ctxCancel()
+
 	c.triggerEnvironmentMetricsPull(
 		ctx,
 		schemas.Environment{

--- a/pkg/controller/webhooks.go
+++ b/pkg/controller/webhooks.go
@@ -18,7 +18,7 @@ func (c *Controller) processPipelineEvent(e goGitlab.PipelineEvent) {
 
 
 	ctx, ctxCancel := context.WithCancel(context.Background())
-	defet ctxCancel()
+	defer ctxCancel()
 
 	var (
 		refKind schemas.RefKind
@@ -154,7 +154,7 @@ schedulePull:
 func (c *Controller) processDeploymentEvent(e goGitlab.DeploymentEvent) {
 
 	ctx, ctxCancel := context.WithCancel(context.Background())
-	defet ctxCancel()
+	defer ctxCancel()
 
 	c.triggerEnvironmentMetricsPull(
 		ctx,


### PR DESCRIPTION
Resolves #620 

Issue: 
In the handlers switch case  request context breaks the go routines at [Line](https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/blob/a2a16c834758b28e0ccbc70eaaeeea39a80784fc/pkg/controller/handlers.go#L127) 

