### PR TITLE
Return only limited fields for each project

### DIFF
--- a/pkg/gitlab/projects.go
+++ b/pkg/gitlab/projects.go
@@ -56,6 +56,7 @@ func (c *Client) ListProjects(ctx context.Context, w config.Wildcard) ([]schemas
 	listOptions := goGitlab.ListOptions{
 		Page:    1,
 		PerPage: 100,
+		Simple:  true,
 	}
 
 	// As a result, the API will return the projects that the owner has access onto.

--- a/pkg/gitlab/projects.go
+++ b/pkg/gitlab/projects.go
@@ -56,7 +56,6 @@ func (c *Client) ListProjects(ctx context.Context, w config.Wildcard) ([]schemas
 	listOptions := goGitlab.ListOptions{
 		Page:    1,
 		PerPage: 100,
-		Simple:  true,
 	}
 
 	// As a result, the API will return the projects that the owner has access onto.
@@ -88,6 +87,7 @@ func (c *Client) ListProjects(ctx context.Context, w config.Wildcard) ([]schemas
 					Archived:    &w.Archived,
 					ListOptions: listOptions,
 					Search:      &w.Search,
+					Simple:      true,
 				},
 				goGitlab.WithContext(ctx),
 			)
@@ -100,6 +100,7 @@ func (c *Client) ListProjects(ctx context.Context, w config.Wildcard) ([]schemas
 					IncludeSubGroups: &w.Owner.IncludeSubgroups,
 					ListOptions:      listOptions,
 					Search:           &w.Search,
+					Simple:           true,
 				},
 				goGitlab.WithContext(ctx),
 			)
@@ -110,6 +111,7 @@ func (c *Client) ListProjects(ctx context.Context, w config.Wildcard) ([]schemas
 					ListOptions: listOptions,
 					Archived:    &w.Archived,
 					Search:      &w.Search,
+					Simple:      true,
 				},
 				goGitlab.WithContext(ctx),
 			)


### PR DESCRIPTION
## Description

We discussed this on GitLab https://gitlab.com/gitlab-org/gitlab/-/issues/387850 to return only limited fields for each project. This is a no-op without authentication, where only simple fields are returned.

Reference: https://docs.gitlab.com/ee/api/projects.html