### PR TITLE
Make the time window of the ratelimiter configurable

### DIFF
--- a/docs/configuration_syntax.md
+++ b/docs/configuration_syntax.md
@@ -90,6 +90,10 @@ gitlab:
   # (optional, default: 1)
   maximum_requests_per_second: 1
 
+  # Time window for the rate limit, in seconds.
+  # (optional, default: 1)
+  time_window: 1
+
 pull:
   projects_from_wildcards:
     # Whether to trigger a discovery or not when the

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -111,6 +111,9 @@ type Gitlab struct {
 
 	// Rate limit for the GitLab API requests/sec
 	MaximumRequestsPerSecond int `default:"1" validate:"gte=1" yaml:"maximum_requests_per_second"`
+
+	// Changes the time window of the rate limiter, in seconds
+	TimeWindow int `default:"1" validate:"gte=1" yaml:"time_window"`
 }
 
 // Redis ..

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,6 +23,7 @@ func TestNew(t *testing.T) {
 	c.Gitlab.EnableHealthCheck = true
 	c.Gitlab.EnableTLSVerify = true
 	c.Gitlab.MaximumRequestsPerSecond = 1
+	c.Gitlab.TimeWindow = 1
 
 	c.Pull.ProjectsFromWildcards.OnInit = true
 	c.Pull.ProjectsFromWildcards.Scheduled = true

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -154,7 +154,7 @@ func (c *Controller) configureGitlab(cfg config.Gitlab, version string) (err err
 	if c.Redis != nil {
 		rl = ratelimit.NewRedisLimiter(c.Redis, cfg.MaximumRequestsPerSecond)
 	} else {
-		rl = ratelimit.NewLocalLimiter(cfg.MaximumRequestsPerSecond)
+		rl = ratelimit.NewLocalLimiter(cfg.MaximumRequestsPerSecond, cfg.TimeWindow)
 	}
 
 	c.Gitlab, err = gitlab.NewClient(gitlab.ClientConfig{

--- a/pkg/gitlab/client_test.go
+++ b/pkg/gitlab/client_test.go
@@ -28,7 +28,7 @@ func getMockedClient() (context.Context, *http.ServeMux, *httptest.Server, *Clie
 
 	c := &Client{
 		Client:      gc,
-		RateLimiter: ratelimit.NewLocalLimiter(100),
+		RateLimiter: ratelimit.NewLocalLimiter(100, 1),
 		RateCounter: ratecounter.NewRateCounter(time.Second),
 	}
 
@@ -47,7 +47,7 @@ func TestNewClient(t *testing.T) {
 		UserAgentVersion: "0.0.0",
 		DisableTLSVerify: true,
 		ReadinessURL:     "https://gitlab.example.com/amialive",
-		RateLimiter:      ratelimit.NewLocalLimiter(10),
+		RateLimiter:      ratelimit.NewLocalLimiter(10, 1),
 	}
 
 	c, err := NewClient(cfg)

--- a/pkg/ratelimit/local.go
+++ b/pkg/ratelimit/local.go
@@ -13,9 +13,9 @@ type Local struct {
 }
 
 // NewLocalLimiter ..
-func NewLocalLimiter(maxRPS int) Limiter {
+func NewLocalLimiter(maxRPS int, TimeWindow int) Limiter {
 	return Local{
-		localRatelimit.New(maxRPS),
+		localRatelimit.New(maxRPS, localRatelimit.Per(time.Duration(TimeWindow)*time.Second)),
 	}
 }
 

--- a/pkg/ratelimit/local_test.go
+++ b/pkg/ratelimit/local_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestNewLocalLimiter(t *testing.T) {
-	assert.IsType(t, Local{}, NewLocalLimiter(10))
+	assert.IsType(t, Local{}, NewLocalLimiter(10, 1))
 }

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -21,7 +21,7 @@ func MeasureTakeDuration(l Limiter) int64 {
 }
 
 func TestLocalTake(t *testing.T) {
-	l := NewLocalLimiter(1)
+	l := NewLocalLimiter(1, 1)
 
 	assert.LessOrEqual(t, MeasureTakeDuration(l), int64(100*time.Millisecond))
 	assert.GreaterOrEqual(t, MeasureTakeDuration(l), int64(time.Second))


### PR DESCRIPTION
The minimum of 1 rps was too much so I made the window of the ratelimiter configurable. 