### PR TITLE
Fix misformed url to Gitlab pipeline

### DIFF
--- a/examples/quickstart/grafana/dashboards/dashboard_pipelines.json
+++ b/examples/quickstart/grafana/dashboards/dashboard_pipelines.json
@@ -766,7 +766,7 @@
                   {
                     "targetBlank": true,
                     "title": "View pipeline #${__value.numeric}",
-                    "url": "https://${GITLAB_HOST}/${__data.fields.project}/pipelines/${__value.numeric}"
+                    "url": "https://${GITLAB_HOST}/${__data.fields.project}/-/pipelines/${__value.numeric}"
                   }
                 ]
               },


### PR DESCRIPTION
Fix link to the relative pipeline on Gitlab wich is actually broken (missing `-/`)