### PR TITLE
fix default branch regexp

### DIFF
--- a/docs/configuration_syntax.md
+++ b/docs/configuration_syntax.md
@@ -243,8 +243,8 @@ project_defaults:
         enabled: true
 
         # Filter for branches to include
-        # (optional, default: "^main|master$" -- main/master branches)
-        regexp: "^main|master$"
+        # (optional, default: "^(?:main|master)$" -- main/master branches)
+        regexp: "^(?:main|master)$"
         
         # Only keep most 'n' recently updated branches
         # (optional, default: 0 -- disabled/keep every branch matching the regexp)"
@@ -354,8 +354,8 @@ projects:
           enabled: true
 
           # Filter for branches to include
-          # (optional, default: "^main|master$" -- main/master branches)
-          regexp: "^main|master$"
+          # (optional, default: "^(?:main|master)$" -- main/master branches)
+          regexp: "^(?:main|master)$"
           
           # Only keep most 'n' recently updated branches
           # (optional, default: 0 -- disabled/keep every branch matching the regexp)"
@@ -481,8 +481,8 @@ wildcards:
           enabled: true
 
           # Filter for branches to include
-          # (optional, default: "^main|master$" -- main/master branches)
-          regexp: "^main|master$"
+          # (optional, default: "^(?:main|master)$" -- main/master branches)
+          regexp: "^(?:main|master)$"
           
           # Only keep most 'n' recently updated branches
           # (optional, default: 0 -- disabled/keep every branch matching the regexp)"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -60,7 +60,7 @@ func TestNew(t *testing.T) {
 	c.ProjectDefaults.Pull.Environments.ExcludeStopped = true
 
 	c.ProjectDefaults.Pull.Refs.Branches.Enabled = true
-	c.ProjectDefaults.Pull.Refs.Branches.Regexp = `^main|master$`
+	c.ProjectDefaults.Pull.Refs.Branches.Regexp = `^(?:main|master)$`
 	c.ProjectDefaults.Pull.Refs.Branches.ExcludeDeleted = true
 
 	c.ProjectDefaults.Pull.Refs.Tags.Enabled = true

--- a/pkg/config/project.go
+++ b/pkg/config/project.go
@@ -50,7 +50,7 @@ type ProjectPullRefsBranches struct {
 	Enabled bool `default:"true" yaml:"enabled"`
 
 	// Filter for branches to include
-	Regexp string `default:"^main|master$" yaml:"regexp"`
+	Regexp string `default:"^(?:main|master)$" yaml:"regexp"`
 
 	// Only keep most 'n' recently updated branches
 	MostRecent uint `default:"0" yaml:"most_recent"`

--- a/pkg/config/project_test.go
+++ b/pkg/config/project_test.go
@@ -17,7 +17,7 @@ func TestNewProject(t *testing.T) {
 	p.Pull.Environments.ExcludeStopped = true
 
 	p.Pull.Refs.Branches.Enabled = true
-	p.Pull.Refs.Branches.Regexp = `^main|master$`
+	p.Pull.Refs.Branches.Regexp = `^(?:main|master)$`
 	p.Pull.Refs.Branches.ExcludeDeleted = true
 
 	p.Pull.Refs.Tags.Enabled = true

--- a/pkg/config/wildcard_test.go
+++ b/pkg/config/wildcard_test.go
@@ -15,7 +15,7 @@ func TestNewWildcard(t *testing.T) {
 	w.Pull.Environments.ExcludeStopped = true
 
 	w.Pull.Refs.Branches.Enabled = true
-	w.Pull.Refs.Branches.Regexp = `^main|master$`
+	w.Pull.Refs.Branches.Regexp = `^(?:main|master)$`
 	w.Pull.Refs.Branches.ExcludeDeleted = true
 
 	w.Pull.Refs.Tags.Enabled = true


### PR DESCRIPTION
The current regex will match `main_foo` or `foo_master` since it resolves to `^main` OR `master$` and not `^main$` OR `^master$`

I added a non-capturing group to the regex to prevent this.