### PR TITLE
Update GitLab logo to new branding in Grafana dashboard quickstart

### DIFF
--- a/examples/quickstart/grafana/dashboards/dashboard_environments.json
+++ b/examples/quickstart/grafana/dashboards/dashboard_environments.json
@@ -428,7 +428,7 @@
       },
       "id": 118,
       "options": {
-        "content": "<p style=\"text-align:center;\"><img src=\"https://www.cloudfoundry.org/wp-content/uploads/2017/10/icon_gitlab_cf@2x.png\" width=80px/></p>",
+        "content": "<p style=\"text-align:center;\"><img src=\"https://about.gitlab.com/images/press/logo/png/gitlab-logo-500.png\" width=100px/></p>",
         "mode": "html"
       },
       "pluginVersion": "7.3.1",

--- a/examples/quickstart/grafana/dashboards/dashboard_jobs.json
+++ b/examples/quickstart/grafana/dashboards/dashboard_jobs.json
@@ -35,7 +35,7 @@
       },
       "id": 116,
       "options": {
-        "content": "<p style=\"text-align:center;\"><img src=\"https://www.cloudfoundry.org/wp-content/uploads/2017/10/icon_gitlab_cf@2x.png\" width=80px/></p>",
+        "content": "<p style=\"text-align:center;\"><img src=\"https://about.gitlab.com/images/press/logo/png/gitlab-logo-500.png\" width=100px/></p>",
         "mode": "html"
       },
       "pluginVersion": "7.3.1",

--- a/examples/quickstart/grafana/dashboards/dashboard_pipelines.json
+++ b/examples/quickstart/grafana/dashboards/dashboard_pipelines.json
@@ -35,7 +35,7 @@
       },
       "id": 116,
       "options": {
-        "content": "<p style=\"text-align:center;\"><img src=\"https://www.cloudfoundry.org/wp-content/uploads/2017/10/icon_gitlab_cf@2x.png\" width=80px/></p>",
+        "content": "<p style=\"text-align:center;\"><img src=\"https://about.gitlab.com/images/press/logo/png/gitlab-logo-500.png\" width=100px/></p>",
         "mode": "html"
       },
       "pluginVersion": "7.3.1",


### PR DESCRIPTION
The Grafana quickstart dashboards are great for getting things going in the docker compose demo. This PR updates the GitLab logo to the new branding, using the official images from the brand presskit URLs that are publicly available. 

During tests, I have also changed the image width to 100px instead of 80px, better fitting the widgets. 

![image](https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/assets/382049/1c964e32-7bcd-4543-9d7a-bf31965faf66)


cc @mvisonneau 