### PR TITLE
gitlab/client: guard against `nil` responses

### DIFF
--- a/pkg/gitlab/client.go
+++ b/pkg/gitlab/client.go
@@ -141,6 +141,10 @@ func (c *Client) rateLimit(ctx context.Context) {
 }
 
 func (c *Client) requestsRemaining(response *goGitlab.Response) {
+	if response == nil {
+		return
+	}
+
 	if remaining := response.Header.Get("ratelimit-remaining"); remaining != "" {
 		c.RequestsRemaining, _ = strconv.Atoi(remaining)
 	}


### PR DESCRIPTION
If there is a network problem, the response might be `nil`. Check in `requestsRemaining` once to avoid adding checks everywhere in the codebase.