### PR TITLE
feat: use keyset pagination for retrieving project CI jobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/vmihailenco/taskq/memqueue/v4 v4.0.0-beta.4
 	github.com/vmihailenco/taskq/redisq/v4 v4.0.0-beta.4
 	github.com/vmihailenco/taskq/v4 v4.0.0-beta.4
-	github.com/xanzy/go-gitlab v0.92.3
+	github.com/xanzy/go-gitlab v0.94.0
 	github.com/xeonx/timeago v1.0.0-rc5
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0
 	go.opentelemetry.io/otel v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/vmihailenco/taskq/taskqtest/v4 v4.0.0-beta.4 h1:HkxNl01xXIxSiZ5gGUEBE
 github.com/vmihailenco/taskq/taskqtest/v4 v4.0.0-beta.4/go.mod h1:eFJBPc15KwfiX5P/1wdQH6s28uflseLuzrTcHGXufek=
 github.com/vmihailenco/taskq/v4 v4.0.0-beta.4 h1:Scybb5OGiu6Vr5R/Py7bseNcPwBKjuTS38VO2oixifA=
 github.com/vmihailenco/taskq/v4 v4.0.0-beta.4/go.mod h1:KcqARv9hRrEUGlJfTq44lNyNPseskPbvFH7G5VWgSKY=
-github.com/xanzy/go-gitlab v0.92.3 h1:bMtUHSV5BIhKeka6RyjLOOMZ31byVGDN5pGWmqBsIUs=
-github.com/xanzy/go-gitlab v0.92.3/go.mod h1:5ryv+MnpZStBH8I/77HuQBsMbBGANtVpLWC15qOjWAw=
+github.com/xanzy/go-gitlab v0.94.0 h1:GmBl2T5zqUHqyjkxFSvsT7CbelGdAH/dmBqUBqS+4BE=
+github.com/xanzy/go-gitlab v0.94.0/go.mod h1:ETg8tcj4OhrB84UEgeE8dSuV/0h4BBL1uOV/qK0vlyI=
 github.com/xeonx/timeago v1.0.0-rc5 h1:pwcQGpaH3eLfPtXeyPA4DmHWjoQt0Ea7/++FwpxqLxg=
 github.com/xeonx/timeago v1.0.0-rc5/go.mod h1:qDLrYEFynLO7y5Ho7w3GwgtYgpy5UfhcXIIQvMKVDkA=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=

--- a/pkg/gitlab/jobs_test.go
+++ b/pkg/gitlab/jobs_test.go
@@ -148,8 +148,8 @@ func TestListRefMostRecentJobs(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "GET", r.Method)
 			expectedQueryParams := url.Values{
-				"page":     []string{"1"},
-				"per_page": []string{"100"},
+				"pagination": []string{"keyset"},
+				"per_page":   []string{"100"},
 			}
 			assert.Equal(t, expectedQueryParams, r.URL.Query())
 			fmt.Fprint(w, `[{"id":3,"name":"foo","ref":"yay"},{"id":4,"name":"bar","ref":"yay"}]`)


### PR DESCRIPTION
With https://github.com/xanzy/go-gitlab/pull/1827, go-gitlab now supports keyset pagination, which is much more efficient for iterating through many pages of data.  This commit switches the GitLab CI
`/api/v4/projects/:id/jobs` API to use keyset pagination.
    
The other pipeline API endpoints need keyset pagination support: https://gitlab.com/gitlab-org/gitlab/-/issues/431632