### PR TITLE
add username / pipeline id for lat pipeline to default labels

### DIFF
--- a/pkg/controller/collectors.go
+++ b/pkg/controller/collectors.go
@@ -3,7 +3,7 @@ package controller
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
-	defaultLabels                = []string{"project", "topics", "kind", "ref", "source", "variables"}
+	defaultLabels                = []string{"project", "topics", "kind", "ref", "source", "variables", "username"}
 	jobLabels                    = []string{"stage", "job_name", "runner_description", "tag_list", "failure_reason"}
 	statusLabels                 = []string{"status"}
 	environmentLabels            = []string{"project", "environment"}

--- a/pkg/controller/collectors.go
+++ b/pkg/controller/collectors.go
@@ -3,7 +3,7 @@ package controller
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
-	defaultLabels                = []string{"project", "topics", "kind", "ref", "source", "variables", "username"}
+	defaultLabels                = []string{"project", "topics", "kind", "ref", "source", "variables", "username", "pipeline_id"}
 	jobLabels                    = []string{"stage", "job_name", "runner_description", "tag_list", "failure_reason"}
 	statusLabels                 = []string{"status"}
 	environmentLabels            = []string{"project", "environment"}

--- a/pkg/schemas/pipelines.go
+++ b/pkg/schemas/pipelines.go
@@ -18,6 +18,8 @@ type Pipeline struct {
 	Source                string
 	Status                string
 	Variables             string
+	TriggeredByUsername   string
+	TriggeredByName       string
 	TestReport            TestReport
 }
 
@@ -73,7 +75,7 @@ func NewPipeline(ctx context.Context, gp goGitlab.Pipeline) Pipeline {
 		timestamp = float64(gp.UpdatedAt.Unix())
 	}
 
-	return Pipeline{
+	result := Pipeline{
 		ID:                    gp.ID,
 		Coverage:              coverage,
 		Timestamp:             timestamp,
@@ -82,6 +84,11 @@ func NewPipeline(ctx context.Context, gp goGitlab.Pipeline) Pipeline {
 		Source:                gp.Source,
 		Status:                gp.Status,
 	}
+	if gp.User != nil {
+		result.TriggeredByName = gp.User.Name
+		result.TriggeredByUsername = gp.User.Username
+	}
+	return result
 }
 
 // NewTestReport ..

--- a/pkg/schemas/ref.go
+++ b/pkg/schemas/ref.go
@@ -61,6 +61,7 @@ func (ref Ref) DefaultLabelsValues() map[string]string {
 		"topics":    ref.Project.Topics,
 		"variables": ref.LatestPipeline.Variables,
 		"source":    ref.LatestPipeline.Source,
+		"username":  ref.LatestPipeline.TriggeredByUsername,
 	}
 }
 

--- a/pkg/schemas/ref.go
+++ b/pkg/schemas/ref.go
@@ -55,13 +55,14 @@ func (refs Refs) Count() int {
 // DefaultLabelsValues ..
 func (ref Ref) DefaultLabelsValues() map[string]string {
 	return map[string]string{
-		"kind":      string(ref.Kind),
-		"project":   ref.Project.Name,
-		"ref":       ref.Name,
-		"topics":    ref.Project.Topics,
-		"variables": ref.LatestPipeline.Variables,
-		"source":    ref.LatestPipeline.Source,
-		"username":  ref.LatestPipeline.TriggeredByUsername,
+		"kind":        string(ref.Kind),
+		"project":     ref.Project.Name,
+		"ref":         ref.Name,
+		"topics":      ref.Project.Topics,
+		"variables":   ref.LatestPipeline.Variables,
+		"source":      ref.LatestPipeline.Source,
+		"username":    ref.LatestPipeline.TriggeredByUsername,
+		"pipeline_id": strconv.Itoa(ref.LatestPipeline.ID),
 	}
 }
 


### PR DESCRIPTION
In the context of actionable alerts we found it useful to add the Gitlab username to the labels.
We didn't extensively test this so I don't know if you can just simply add it like this without any problems, but it seems to work for us.
Maybe there is a smarter way to do this because right now the labels are probably being thrown on metrics where they don't belong.
