### PR TITLE
fix environment id hyperlink NaN

### DIFF
--- a/examples/quickstart/grafana/dashboards/dashboard_environments.json
+++ b/examples/quickstart/grafana/dashboards/dashboard_environments.json
@@ -926,8 +926,8 @@
                 "value": [
                   {
                     "targetBlank": true,
-                    "title": "View environment #${__value.numeric}",
-                    "url": "https://${GITLAB_HOST}/${__data.fields.project:raw}/-/environments/${__value.numeric}"
+                    "title": "View environment #${__value.text}",
+                    "url": "https://${GITLAB_HOST}/${__data.fields.project:raw}/-/environments/${__value.text}"
                   }
                 ]
               },


### PR DESCRIPTION
The hyperlink for the Environment ID is shown as 'NaN' (and therefore not working) if mapped as numeric instead of text
Before
![image](https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/assets/91274455/76321f61-de43-4742-8708-fa5d3e5f4776)

After
![image](https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/assets/91274455/7037a2cd-7887-4120-b15f-55f3bbbdacba)
