### PR TITLE
webhooks: only pull project for which request was received

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -77,6 +77,7 @@ func (c *Controller) registerTasks() {
 		schemas.TaskTypePullEnvironmentsFromProject:  c.TaskHandlerPullEnvironmentsFromProject,
 		schemas.TaskTypePullEnvironmentsFromProjects: c.TaskHandlerPullEnvironmentsFromProjects,
 		schemas.TaskTypePullMetrics:                  c.TaskHandlerPullMetrics,
+		schemas.TaskTypePullProject:                  c.TaskHandlerPullProject,
 		schemas.TaskTypePullProjectsFromWildcard:     c.TaskHandlerPullProjectsFromWildcard,
 		schemas.TaskTypePullProjectsFromWildcards:    c.TaskHandlerPullProjectsFromWildcards,
 		schemas.TaskTypePullRefMetrics:               c.TaskHandlerPullRefMetrics,

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -71,6 +71,13 @@ func NewTaskController(ctx context.Context, r *redis.Client, maximumJobsQueueSiz
 	return
 }
 
+// TaskHandlerPullProject ..
+func (c *Controller) TaskHandlerPullProject(ctx context.Context, name string) error {
+	defer c.unqueueTask(ctx, schemas.TaskTypePullProject, name)
+
+	return c.PullProject(ctx, name)
+}
+
 // TaskHandlerPullProjectsFromWildcard ..
 func (c *Controller) TaskHandlerPullProjectsFromWildcard(ctx context.Context, id string, w config.Wildcard) error {
 	defer c.unqueueTask(ctx, schemas.TaskTypePullProjectsFromWildcard, id)

--- a/pkg/controller/webhooks.go
+++ b/pkg/controller/webhooks.go
@@ -99,9 +99,9 @@ func (c *Controller) triggerRefMetricsPull(ctx context.Context, ref schemas.Ref)
 
 		// Perhaps the project is discoverable through a wildcard
 		if !projectExists && len(c.Config.Wildcards) > 0 {
-			for id, w := range c.Config.Wildcards {
+			for _, w := range c.Config.Wildcards {
 				// If in all our wildcards we have one which can potentially match the project ref
-				// received, we trigger a scan
+				// received, we trigger a pull of the project
 				matches, err := isRefMatchingWilcard(w, ref)
 				if err != nil {
 					log.WithContext(ctx).
@@ -112,8 +112,8 @@ func (c *Controller) triggerRefMetricsPull(ctx context.Context, ref schemas.Ref)
 				}
 
 				if matches {
-					c.ScheduleTask(context.TODO(), schemas.TaskTypePullProjectsFromWildcard, strconv.Itoa(id), strconv.Itoa(id), w)
-					log.WithFields(logFields).Info("project ref not currently exported but its configuration matches a wildcard, triggering a pull of the projects from this wildcard")
+					c.ScheduleTask(context.TODO(), schemas.TaskTypePullProject, ref.Project.Name)
+					log.WithFields(logFields).Info("project ref not currently exported but its configuration matches a wildcard, triggering a pull of the project")
 				} else {
 					log.WithFields(logFields).Debug("project ref not matching wildcard, skipping..")
 				}
@@ -213,9 +213,9 @@ func (c *Controller) triggerEnvironmentMetricsPull(ctx context.Context, env sche
 
 		// Perhaps the project is discoverable through a wildcard
 		if !projectExists && len(c.Config.Wildcards) > 0 {
-			for id, w := range c.Config.Wildcards {
+			for _, w := range c.Config.Wildcards {
 				// If in all our wildcards we have one which can potentially match the env
-				// received, we trigger a scan
+				// received, we trigger a pull of the project
 				matches, err := isEnvMatchingWilcard(w, env)
 				if err != nil {
 					log.WithContext(ctx).
@@ -226,8 +226,8 @@ func (c *Controller) triggerEnvironmentMetricsPull(ctx context.Context, env sche
 				}
 
 				if matches {
-					c.ScheduleTask(ctx, schemas.TaskTypePullProjectsFromWildcard, strconv.Itoa(id), strconv.Itoa(id), w)
-					log.WithFields(logFields).Info("project environment not currently exported but its configuration matches a wildcard, triggering a pull of the projects from this wildcard")
+					c.ScheduleTask(context.TODO(), schemas.TaskTypePullProject, env.ProjectName)
+					log.WithFields(logFields).Info("project environment not currently exported but its configuration matches a wildcard, triggering a pull of the project")
 				} else {
 					log.WithFields(logFields).Debug("project ref not matching wildcard, skipping..")
 				}

--- a/pkg/schemas/tasks.go
+++ b/pkg/schemas/tasks.go
@@ -4,6 +4,9 @@ package schemas
 type TaskType string
 
 const (
+	// TaskTypePullProject ..
+	TaskTypePullProject TaskType = "PullProject"
+
 	// TaskTypePullProjectsFromWildcard ..
 	TaskTypePullProjectsFromWildcard TaskType = "PullProjectsFromWildcard"
 


### PR DESCRIPTION
If a webhook request's project matches a wildcard, pull only that project instead of pulling the entire wildcard (which can be expensive for wildcards matching many projects).

Fixes #281