### PR TITLE
Add gitlab-health-url flag and envvar

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -64,6 +64,11 @@ func NewApp(version string, start time.Time) (app *cli.App) {
 					EnvVars: []string{"GCPE_WEBHOOK_SECRET_TOKEN"},
 					Usage:   "`token` used to authenticate legitimate requests (overrides config file parameter)",
 				},
+				&cli.StringFlag{
+					Name:    "gitlab-health-url",
+					EnvVars: []string{"GCPE_GITLAB_HEALTH_URL"},
+					Usage:   "GitLab health URL (overrides config file parameter)",
+				},
 			},
 		},
 		{

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -121,6 +121,11 @@ func configCliOverrides(ctx *cli.Context, cfg *config.Config) {
 	if ctx.String("redis-url") != "" {
 		cfg.Redis.URL = ctx.String("redis-url")
 	}
+
+	if healthURL := ctx.String("gitlab-health-url"); healthURL != "" {
+		cfg.Gitlab.HealthURL = healthURL
+		cfg.Gitlab.EnableHealthCheck = true
+	}
 }
 
 func assertStringVariableDefined(ctx *cli.Context, k string) {

--- a/internal/cmd/utils_test.go
+++ b/internal/cmd/utils_test.go
@@ -84,6 +84,15 @@ server:
 	cfg, err = configure(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, "secret", cfg.Server.Webhook.SecretToken)
+
+	// Test health url flag
+	healthURL := "https://gitlab.com/-/readiness?token"
+	flags.String("gitlab-health-url", healthURL, "")
+
+	cfg, err = configure(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, cfg.Gitlab.HealthURL, healthURL)
+	assert.True(t, cfg.Gitlab.EnableHealthCheck)
 }
 
 func TestExit(t *testing.T) {


### PR DESCRIPTION
Because GitLab requires a token for readiness and liveness checks so it might be desirable to store it in a Secret / environment variable instead of in the plaintext config.
This option is already documented in configuration_syntax.md but wasn't implemented.