### PR TITLE
fix: garbage collection of merge-request refs when webhook mode

### DIFF
--- a/pkg/controller/handlers.go
+++ b/pkg/controller/handlers.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 
@@ -100,7 +100,7 @@ func (c *Controller) WebhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	payload, err := ioutil.ReadAll(r.Body)
+	payload, err := io.ReadAll(r.Body)
 	if err != nil {
 		logger.
 			WithError(err).
@@ -133,6 +133,8 @@ func (c *Controller) WebhookHandler(w http.ResponseWriter, r *http.Request) {
 		go c.processPushEvent(ctx, *event)
 	case *gitlab.TagEvent:
 		go c.processTagEvent(ctx, *event)
+	case *gitlab.MergeEvent:
+		go c.processMergeEvent(ctx, *event)
 	default:
 		logger.
 			WithField("event-type", reflect.TypeOf(event).String()).

--- a/pkg/controller/webhooks.go
+++ b/pkg/controller/webhooks.go
@@ -141,7 +141,6 @@ func (c *Controller) processMergeEvent(ctx context.Context, e goGitlab.MergeEven
 			WithField("merge-request-event-type", e.ObjectAttributes.Action).
 			Debug("received a non supported merge-request event type as a webhook")
 	}
-
 }
 
 func (c *Controller) triggerRefMetricsPull(ctx context.Context, ref schemas.Ref) {

--- a/pkg/controller/webhooks.go
+++ b/pkg/controller/webhooks.go
@@ -136,7 +136,12 @@ func (c *Controller) processMergeEvent(ctx context.Context, e goGitlab.MergeEven
 		_ = deleteRef(ctx, c.Store, ref, "received merge request close event from webhook")
 	case "merge":
 		_ = deleteRef(ctx, c.Store, ref, "received merge request merge event from webhook")
+	default:
+		log.
+			WithField("merge-request-event-type", e.ObjectAttributes.Action).
+			Debug("received a non supported merge-request event type as a webhook")
 	}
+
 }
 
 func (c *Controller) triggerRefMetricsPull(ctx context.Context, ref schemas.Ref) {

--- a/pkg/controller/webhooks.go
+++ b/pkg/controller/webhooks.go
@@ -133,21 +133,9 @@ func (c *Controller) processMergeEvent(ctx context.Context, e goGitlab.MergeEven
 
 	switch e.ObjectAttributes.Action {
 	case "close":
-		c.triggerRefDeletion(ctx, ref)
+		_ = deleteRef(ctx, c.Store, ref, "received merge request close event from webhook")
 	case "merge":
-		c.triggerRefDeletion(ctx, ref)
-	}
-}
-
-func (c *Controller) triggerRefDeletion(ctx context.Context, ref schemas.Ref) {
-	err := c.Store.DelRef(ctx, ref.Key())
-	if err != nil {
-		log.WithContext(ctx).
-			WithFields(log.Fields{
-				"project-name": ref.Project.Name,
-				"ref":          ref.Name,
-			}).
-			Error("failed deleting ref")
+		_ = deleteRef(ctx, c.Store, ref, "received merge request merge event from webhook")
 	}
 }
 

--- a/pkg/controller/webhooks_test.go
+++ b/pkg/controller/webhooks_test.go
@@ -55,29 +55,3 @@ func TestTriggerEnvironmentMetricsPull(t *testing.T) {
 	c.triggerEnvironmentMetricsPull(ctx, env1)
 	c.triggerEnvironmentMetricsPull(ctx, env2)
 }
-
-func TestTriggerRefDeletion(t *testing.T) {
-	ctx, c, _, srv := newTestController(config.Config{})
-	srv.Close()
-
-	ref1 := schemas.Ref{
-		Project: schemas.NewProject("group/foo"),
-		Name:    "main",
-	}
-
-	p2 := schemas.NewProject("group/bar")
-	ref2 := schemas.Ref{
-		Project: p2,
-		Name:    "main",
-	}
-
-	assert.NoError(t, c.Store.SetRef(ctx, ref1))
-	assert.NoError(t, c.Store.SetRef(ctx, ref2))
-	assert.NoError(t, c.Store.SetProject(ctx, p2))
-
-	c.triggerRefDeletion(ctx, ref1)
-	c.triggerRefDeletion(ctx, ref2)
-
-	assert.Nil(t, c.Store.GetRef(ctx, &ref1))
-	assert.Nil(t, c.Store.GetRef(ctx, &ref2))
-}

--- a/pkg/controller/webhooks_test.go
+++ b/pkg/controller/webhooks_test.go
@@ -55,3 +55,29 @@ func TestTriggerEnvironmentMetricsPull(t *testing.T) {
 	c.triggerEnvironmentMetricsPull(ctx, env1)
 	c.triggerEnvironmentMetricsPull(ctx, env2)
 }
+
+func TestTriggerRefDeletion(t *testing.T) {
+	ctx, c, _, srv := newTestController(config.Config{})
+	srv.Close()
+
+	ref1 := schemas.Ref{
+		Project: schemas.NewProject("group/foo"),
+		Name:    "main",
+	}
+
+	p2 := schemas.NewProject("group/bar")
+	ref2 := schemas.Ref{
+		Project: p2,
+		Name:    "main",
+	}
+
+	assert.NoError(t, c.Store.SetRef(ctx, ref1))
+	assert.NoError(t, c.Store.SetRef(ctx, ref2))
+	assert.NoError(t, c.Store.SetProject(ctx, p2))
+
+	c.triggerRefDeletion(ctx, ref1)
+	c.triggerRefDeletion(ctx, ref2)
+
+	assert.Nil(t, c.Store.GetRef(ctx, &ref1))
+	assert.Nil(t, c.Store.GetRef(ctx, &ref2))
+}


### PR DESCRIPTION
When using the webhook mode we noticed that a bunch of refs were never garage-collected and kept accumulating in the memory/redis.

The solution uses the `Merge Request Hook` to delete those refs when the MR is closed or merged
