### PR TITLE
feat: detect pipeline with status success-with-warnings

### DIFF
--- a/pkg/schemas/pipelines.go
+++ b/pkg/schemas/pipelines.go
@@ -80,7 +80,7 @@ func NewPipeline(ctx context.Context, gp goGitlab.Pipeline) Pipeline {
 		DurationSeconds:       float64(gp.Duration),
 		QueuedDurationSeconds: float64(gp.QueuedDuration),
 		Source:                gp.Source,
-		Status:                gp.Status,
+		Status:                gp.DetailedStatus.Group,
 	}
 }
 

--- a/pkg/schemas/pipelines_test.go
+++ b/pkg/schemas/pipelines_test.go
@@ -14,29 +14,78 @@ func TestNewPipeline(t *testing.T) {
 	startedAt := time.Date(2020, 10, 1, 13, 5, 10, 0, time.UTC)
 	updatedAt := time.Date(2020, 10, 1, 13, 5, 50, 0, time.UTC)
 
-	gitlabPipeline := goGitlab.Pipeline{
-		ID:             21,
-		Coverage:       "25.6",
-		CreatedAt:      &createdAt,
-		StartedAt:      &startedAt,
-		UpdatedAt:      &updatedAt,
-		Duration:       15,
-		QueuedDuration: 5,
-		Source:         "schedule",
-		Status:         "running",
+	testCases := []struct {
+		status         string
+		detailedStatus goGitlab.DetailedStatus
+		expectedStatus string
+	}{
+		{
+			"running",
+			goGitlab.DetailedStatus{
+				Text:  "Running",
+				Label: "running",
+				Group: "running",
+			},
+			"running",
+		},
+		{
+			"success",
+			goGitlab.DetailedStatus{
+				Text:  "Passed",
+				Label: "passed",
+				Group: "success",
+			},
+			"success",
+		},
+		{
+			"canceled",
+			goGitlab.DetailedStatus{
+				Text:  "Canceled",
+				Label: "canceled",
+				Group: "canceled",
+			},
+			"canceled",
+		},
+		{
+			"success",
+			goGitlab.DetailedStatus{
+				Text:  "Warning",
+				Label: "passed with warnings",
+				Group: "success-with-warnings",
+			},
+			"success-with-warnings",
+		},
 	}
 
-	expectedPipeline := Pipeline{
-		ID:                    21,
-		Coverage:              25.6,
-		Timestamp:             1.60155755e+09,
-		DurationSeconds:       15,
-		QueuedDurationSeconds: 5,
-		Source:                "schedule",
-		Status:                "running",
+	for _, tc := range testCases {
+		t.Run(tc.status, func(t *testing.T) {
+			gitlabPipeline := goGitlab.Pipeline{
+				ID:             21,
+				Coverage:       "25.6",
+				CreatedAt:      &createdAt,
+				StartedAt:      &startedAt,
+				UpdatedAt:      &updatedAt,
+				Duration:       15,
+				QueuedDuration: 5,
+				Source:         "schedule",
+				Status:         tc.status,
+				DetailedStatus: &tc.detailedStatus,
+			}
+
+			expectedPipeline := Pipeline{
+				ID:                    21,
+				Coverage:              25.6,
+				Timestamp:             1.60155755e+09,
+				DurationSeconds:       15,
+				QueuedDurationSeconds: 5,
+				Source:                "schedule",
+				Status:                tc.expectedStatus,
+			}
+
+			assert.Equal(t, expectedPipeline, NewPipeline(context.Background(), gitlabPipeline))
+		})
 	}
 
-	assert.Equal(t, expectedPipeline, NewPipeline(context.Background(), gitlabPipeline))
 }
 
 func TestNewTestReport(t *testing.T) {


### PR DESCRIPTION
Use pipeline detailed status to expose if the pipeline was successful with a warning (job with allow_failure: true)

Attempt to implement suggestion from https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/issues/123

