### PR TITLE
FIX - "gitlab-ci-pipelines-exporter monitor" for TCP localhost:port

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,14 +346,15 @@ To use it, you have to start your exporter with the following flag `--internal-m
 You can whether use a TCP or UNIX socket eg:
 
 ```
-~$ gitlab-ci-pipelines-exporter -m 'unix://gcpe-monitor.sock' run
+~$ gitlab-ci-pipelines-exporter -m 'unix:///gcpe-monitor.sock' run
 ~$ gitlab-ci-pipelines-exporter -m 'tcp://127.0.0.1:9000' run
 ```
 
-To use the monitor CLI, you need to be able to access the monitoring socket and reuse the same flag:
+Unix socket address format is denoted here: https://github.com/grpc/grpc/blob/master/doc/naming.md#detailed-design
 
+To use the monitor CLI, you need to be able to access the monitoring socket and reuse the same flag:
 ```
-export GCPE_INTERNAL_MONITORING_LISTENER_ADDRESS='unix://gcpe-monitor.sock'
+export GCPE_INTERNAL_MONITORING_LISTENER_ADDRESS='unix:///gcpe-monitor.sock'
 ~$ gitlab-ci-pipelines-exporter run &
 ~$ gitlab-ci-pipelines-exporter monitor
 ```

--- a/pkg/monitor/client/client.go
+++ b/pkg/monitor/client/client.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"net/url"
 
 	log "github.com/sirupsen/logrus"
@@ -17,12 +16,17 @@ type Client struct {
 }
 
 // NewClient ..
-func NewClient(ctx context.Context, endpoint *url.URL) *Client {
+func NewClient(endpoint *url.URL) *Client {
 	log.WithField("endpoint", endpoint.String()).Debug("establishing gRPC connection to the server..")
 
-	conn, err := grpc.DialContext(
-		ctx,
-		endpoint.String(),
+	target_address := endpoint.String()
+	if endpoint.Scheme != "unix" {
+		// Drop the schema and just use "host:port" if we're dealing with local addresses
+		target_address = endpoint.Host
+	}
+
+	conn, err := grpc.NewClient(
+		target_address,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {

--- a/pkg/monitor/ui/ui.go
+++ b/pkg/monitor/ui/ui.go
@@ -225,7 +225,7 @@ func newModel(version string, endpoint *url.URL) (m *model) {
 		vp:              viewport.Model{},
 		telemetryStream: make(chan *pb.Telemetry),
 		progress:        &p,
-		client:          client.NewClient(context.TODO(), endpoint),
+		client:          client.NewClient(endpoint),
 	}
 
 	return


### PR DESCRIPTION
Addressing the use of "deprecated" https://pkg.go.dev/google.golang.org/grpc#DialContext, for the recommended function and fix docs for unix and tcp "monitor" behaviour

Related to: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/issues/952