### PR TITLE
Fix - Queue size consumption % should be based on the maxiumum queue size

### DIFF
--- a/pkg/monitor/server/server.go
+++ b/pkg/monitor/server/server.go
@@ -144,7 +144,7 @@ func (s *Server) GetTelemetry(_ *pb.Empty, ts pb.Monitor_GetTelemetryServer) (er
 			return
 		}
 
-		telemetry.TasksBufferUsage = float64(queuedTasks) / 1000
+		telemetry.TasksBufferUsage = float64(queuedTasks) / float64(s.cfg.Gitlab.MaximumJobsQueueSize)
 
 		telemetry.TasksExecutedCount, err = s.store.ExecutedTasksCount(ctx)
 		if err != nil {


### PR DESCRIPTION
There was a config variable added, so this "monitor" calculation should be based on this variable rather than magic number