### PR TITLE
Avoid duplicate job status metrics due to failure_reason in MetricKey

### DIFF
--- a/pkg/schemas/metric.go
+++ b/pkg/schemas/metric.go
@@ -155,7 +155,6 @@ func (m Metric) Key() MetricKey {
 			m.Labels["stage"],
 			m.Labels["tag_list"],
 			m.Labels["job_name"],
-			m.Labels["failure_reason"],
 		})
 
 	case MetricKindEnvironmentBehindCommitsCount, MetricKindEnvironmentBehindDurationSeconds, MetricKindEnvironmentDeploymentCount, MetricKindEnvironmentDeploymentDurationSeconds, MetricKindEnvironmentDeploymentJobID, MetricKindEnvironmentDeploymentStatus, MetricKindEnvironmentDeploymentTimestamp, MetricKindEnvironmentInformation:


### PR DESCRIPTION
This fixes #814

Including `failure_reason` in the key caused separate metrics for one job of succeeded and failed pipeline runs. As a result it became impossible to differentiate between them.

`failure_reason` provides context for the metric but is not suitable as a part of the metric key for storage.