### PR TITLE
Fix readiness check response body leak

### DIFF
--- a/pkg/gitlab/client.go
+++ b/pkg/gitlab/client.go
@@ -125,6 +125,7 @@ func (c *Client) ReadinessCheck(ctx context.Context) healthcheck.Check {
 		if resp == nil {
 			return fmt.Errorf("HTTP error: empty response")
 		}
+		defer resp.Body.Close()
 
 		if err == nil && resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("HTTP error: %d", resp.StatusCode)


### PR DESCRIPTION
## Summary
- ensure HTTP response body is closed in the readiness check

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68494e89298c83338d1bab591214751a