### PR TITLE
Fix metrics doc project_defaults

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -84,17 +84,17 @@ Those are not fetched by default, you need to set `project_defaults.pull.pipelin
 ### Test Suite Name
 
 Name of the test suite.
-This is not fetched by default, you need to set `project_default.pull.pipeline.test_reports.enabled` to **true**
+This is not fetched by default, you need to set `project_defaults.pull.pipeline.test_reports.enabled` to **true**
 
 ### Test Case Name
 
 Name of the test case.
-This is not fetched by default, you need to set `project_default.pull.pipeline.test_reports.test_cases.enabled` to **true**
+This is not fetched by default, you need to set `project_defaults.pull.pipeline.test_reports.test_cases.enabled` to **true**
 
 ### Test Case ClassName
 
 Name of the test case classname.
-This is not fetched by default, you need to set `project_default.pull.pipeline.test_reports.test_cases.enabled` to **true**
+This is not fetched by default, you need to set `project_defaults.pull.pipeline.test_reports.test_cases.enabled` to **true**
 
 ### Environment
 


### PR DESCRIPTION
## Summary
- fix configuration keys in metrics documentation

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68494fcc99408333b2cbb245b429ea34