### PR TITLE
Add project_id label to all exported metrics

### DIFF
--- a/pkg/controller/collectors.go
+++ b/pkg/controller/collectors.go
@@ -3,10 +3,10 @@ package controller
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
-	defaultLabels                = []string{"project", "topics", "kind", "ref", "source", "variables"}
+	defaultLabels                = []string{"project", "project_id", "topics", "kind", "ref", "source", "variables"}
 	jobLabels                    = []string{"stage", "job_name", "runner_description", "tag_list", "failure_reason"}
 	statusLabels                 = []string{"status"}
-	environmentLabels            = []string{"project", "environment"}
+	environmentLabels            = []string{"project", "project_id", "environment"}
 	environmentInformationLabels = []string{"environment_id", "external_url", "kind", "ref", "latest_commit_short_id", "current_commit_short_id", "available", "username"}
 	testSuiteLabels              = []string{"test_suite_name"}
 	testCaseLabels               = []string{"test_case_name", "test_case_classname"}

--- a/pkg/controller/environments.go
+++ b/pkg/controller/environments.go
@@ -10,6 +10,15 @@ import (
 
 // PullEnvironmentsFromProject ..
 func (c *Controller) PullEnvironmentsFromProject(ctx context.Context, p schemas.Project) (err error) {
+	if p.ID == 0 {
+		if err := c.resolveProjectID(ctx, &p); err != nil {
+			log.WithContext(ctx).
+				WithField("project-name", p.Name).
+				WithError(err).
+				Warn("failed to resolve project ID from GitLab API")
+		}
+	}
+
 	var envs schemas.Environments
 
 	envs, err = c.Gitlab.GetProjectEnvironments(ctx, p)

--- a/pkg/controller/environments_test.go
+++ b/pkg/controller/environments_test.go
@@ -130,6 +130,7 @@ func TestPullEnvironmentMetricsSucceed(t *testing.T) {
 	metrics, _ := c.Store.Metrics(ctx)
 	labels := map[string]string{
 		"project":     "foo",
+		"project_id":  "0",
 		"environment": "prod",
 	}
 

--- a/pkg/controller/jobs_test.go
+++ b/pkg/controller/jobs_test.go
@@ -117,6 +117,7 @@ func TestProcessJobMetrics(t *testing.T) {
 	metrics, _ := c.Store.Metrics(ctx)
 	labels := map[string]string{
 		"project":            ref.Project.Name,
+		"project_id":         "0",
 		"topics":             ref.Project.Topics,
 		"ref":                ref.Name,
 		"kind":               string(ref.Kind),

--- a/pkg/controller/metrics_test.go
+++ b/pkg/controller/metrics_test.go
@@ -44,12 +44,13 @@ func TestExportMetrics(_ *testing.T) {
 	m1 := schemas.Metric{
 		Kind: schemas.MetricKindCoverage,
 		Labels: prometheus.Labels{
-			"project":   "foo",
-			"topics":    "alpha",
-			"ref":       "bar",
-			"kind":      "branch",
-			"source":    "schedule",
-			"variables": "beta",
+			"project":    "foo",
+			"project_id": "0",
+			"topics":     "alpha",
+			"ref":        "bar",
+			"kind":       "branch",
+			"source":     "schedule",
+			"variables":  "beta",
 		},
 		Value: float64(107.7),
 	}
@@ -57,12 +58,13 @@ func TestExportMetrics(_ *testing.T) {
 	m2 := schemas.Metric{
 		Kind: schemas.MetricKindRunCount,
 		Labels: prometheus.Labels{
-			"project":   "foo",
-			"topics":    "alpha",
-			"ref":       "bar",
-			"kind":      "branch",
-			"source":    "schedule",
-			"variables": "beta",
+			"project":    "foo",
+			"project_id": "0",
+			"topics":     "alpha",
+			"ref":        "bar",
+			"kind":       "branch",
+			"source":     "schedule",
+			"variables":  "beta",
 		},
 		Value: float64(10),
 	}

--- a/pkg/controller/pipelines_test.go
+++ b/pkg/controller/pipelines_test.go
@@ -56,12 +56,13 @@ func TestPullRefMetricsSucceed(t *testing.T) {
 	// Check if all the metrics exist
 	metrics, _ := c.Store.Metrics(ctx)
 	labels := map[string]string{
-		"kind":      string(schemas.RefKindBranch),
-		"project":   "foo",
-		"ref":       "bar",
-		"topics":    "",
-		"variables": "foo:bar",
-		"source":    "schedule",
+		"kind":       string(schemas.RefKindBranch),
+		"project":    "foo",
+		"project_id": "0",
+		"ref":        "bar",
+		"topics":     "",
+		"variables":  "foo:bar",
+		"source":     "schedule",
 	}
 
 	runCount := schemas.Metric{
@@ -137,12 +138,13 @@ func TestPullRefMetricsUpdatingPipeline(t *testing.T) {
 	p.Pull.Pipeline.Variables.Enabled = true
 
 	labels := map[string]string{
-		"kind":      string(schemas.RefKindBranch),
-		"project":   "foo",
-		"ref":       "bar",
-		"topics":    "",
-		"variables": "foo:bar",
-		"source":    "pipeline",
+		"kind":       string(schemas.RefKindBranch),
+		"project":    "foo",
+		"project_id": "0",
+		"ref":        "bar",
+		"topics":     "",
+		"variables":  "foo:bar",
+		"source":     "pipeline",
 	}
 
 	// when
@@ -185,12 +187,13 @@ func TestPullRefMetricsUpdatingPipeline(t *testing.T) {
 	}`
 
 	labels = map[string]string{
-		"kind":      string(schemas.RefKindBranch),
-		"project":   "foo",
-		"ref":       "bar",
-		"topics":    "",
-		"variables": "foo:bar",
-		"source":    "pipeline",
+		"kind":       string(schemas.RefKindBranch),
+		"project":    "foo",
+		"project_id": "0",
+		"ref":        "bar",
+		"topics":     "",
+		"variables":  "foo:bar",
+		"source":     "pipeline",
 	}
 
 	// when again
@@ -266,12 +269,13 @@ func TestPullRefTestReportMetrics(t *testing.T) {
 	// Check if all the metrics exist
 	metrics, _ := c.Store.Metrics(ctx)
 	labels := map[string]string{
-		"kind":      string(schemas.RefKindBranch),
-		"project":   "foo",
-		"ref":       "bar",
-		"topics":    "",
-		"variables": "foo:bar",
-		"source":    "schedule",
+		"kind":       string(schemas.RefKindBranch),
+		"project":    "foo",
+		"project_id": "0",
+		"ref":        "bar",
+		"topics":     "",
+		"variables":  "foo:bar",
+		"source":     "schedule",
 	}
 
 	trTotalTime := schemas.Metric{

--- a/pkg/controller/projects.go
+++ b/pkg/controller/projects.go
@@ -9,6 +9,19 @@ import (
 	"github.com/mvisonneau/gitlab-ci-pipelines-exporter/pkg/schemas"
 )
 
+// resolveProjectID fetches the project ID from the GitLab API and updates
+// both the provided project and the store.
+func (c *Controller) resolveProjectID(ctx context.Context, p *schemas.Project) error {
+	gp, err := c.Gitlab.GetProject(ctx, p.Name)
+	if err != nil {
+		return err
+	}
+
+	p.ID = gp.ID
+
+	return c.Store.SetProject(ctx, *p)
+}
+
 // PullProject ..
 func (c *Controller) PullProject(ctx context.Context, name string, pull config.ProjectPull) error {
 	gp, err := c.Gitlab.GetProject(ctx, name)
@@ -17,6 +30,7 @@ func (c *Controller) PullProject(ctx context.Context, name string, pull config.P
 	}
 
 	p := schemas.NewProject(gp.PathWithNamespace)
+	p.ID = gp.ID
 	p.Pull = pull
 
 	projectExists, err := c.Store.ProjectExists(ctx, p.Key())

--- a/pkg/controller/projects_test.go
+++ b/pkg/controller/projects_test.go
@@ -25,6 +25,7 @@ func TestPullProjectsFromWildcard(t *testing.T) {
 
 	projects, _ := c.Store.Projects(ctx)
 	p1 := schemas.NewProject("bar")
+	p1.ID = 2
 
 	expectedProjects := schemas.Projects{
 		p1.Key(): p1,

--- a/pkg/controller/refs.go
+++ b/pkg/controller/refs.go
@@ -77,6 +77,15 @@ func (c *Controller) GetRefs(ctx context.Context, p schemas.Project) (
 
 // PullRefsFromProject ..
 func (c *Controller) PullRefsFromProject(ctx context.Context, p schemas.Project) error {
+	if p.ID == 0 {
+		if err := c.resolveProjectID(ctx, &p); err != nil {
+			log.WithContext(ctx).
+				WithField("project-name", p.Name).
+				WithError(err).
+				Warn("failed to resolve project ID from GitLab API")
+		}
+	}
+
 	refs, err := c.GetRefs(ctx, p)
 	if err != nil {
 		return err

--- a/pkg/controller/webhooks.go
+++ b/pkg/controller/webhooks.go
@@ -31,8 +31,11 @@ func (c *Controller) processPipelineEvent(ctx context.Context, e goGitlab.Pipeli
 		refKind = schemas.RefKindBranch
 	}
 
+	p := schemas.NewProject(e.Project.PathWithNamespace)
+	p.ID = e.Project.ID
+
 	c.triggerRefMetricsPull(ctx, schemas.NewRef(
-		schemas.NewProject(e.Project.PathWithNamespace),
+		p,
 		refKind,
 		refName,
 	))
@@ -59,8 +62,11 @@ func (c *Controller) processJobEvent(ctx context.Context, e goGitlab.JobEvent) {
 		return
 	}
 
+	p := schemas.NewProject(project.PathWithNamespace)
+	p.ID = project.ID
+
 	c.triggerRefMetricsPull(ctx, schemas.NewRef(
-		schemas.NewProject(project.PathWithNamespace),
+		p,
 		refKind,
 		refName,
 	))
@@ -87,8 +93,11 @@ func (c *Controller) processPushEvent(ctx context.Context, e goGitlab.PushEvent)
 			return
 		}
 
+		pushProject := schemas.NewProject(e.Project.PathWithNamespace)
+		pushProject.ID = e.Project.ID
+
 		_ = deleteRef(ctx, c.Store, schemas.NewRef(
-			schemas.NewProject(e.Project.PathWithNamespace),
+			pushProject,
 			refKind,
 			refName,
 		), "received branch deletion push event from webhook")
@@ -116,8 +125,11 @@ func (c *Controller) processTagEvent(ctx context.Context, e goGitlab.TagEvent) {
 			return
 		}
 
+		tagProject := schemas.NewProject(e.Project.PathWithNamespace)
+		tagProject.ID = e.Project.ID
+
 		_ = deleteRef(ctx, c.Store, schemas.NewRef(
-			schemas.NewProject(e.Project.PathWithNamespace),
+			tagProject,
 			refKind,
 			refName,
 		), "received tag deletion tag event from webhook")
@@ -125,8 +137,11 @@ func (c *Controller) processTagEvent(ctx context.Context, e goGitlab.TagEvent) {
 }
 
 func (c *Controller) processMergeEvent(ctx context.Context, e goGitlab.MergeEvent) {
+	mergeProject := schemas.NewProject(e.Project.PathWithNamespace)
+	mergeProject.ID = e.Project.ID
+
 	ref := schemas.NewRef(
-		schemas.NewProject(e.Project.PathWithNamespace),
+		mergeProject,
 		schemas.RefKindMergeRequest,
 		strconv.FormatInt(e.ObjectAttributes.IID, 10),
 	)
@@ -266,6 +281,7 @@ func (c *Controller) processDeploymentEvent(ctx context.Context, e goGitlab.Depl
 		ctx,
 		schemas.Environment{
 			ProjectName: e.Project.PathWithNamespace,
+			ProjectID:   e.Project.ID,
 			Name:        e.Environment,
 		},
 	)

--- a/pkg/gitlab/environments.go
+++ b/pkg/gitlab/environments.go
@@ -59,6 +59,7 @@ func (c *Client) GetProjectEnvironments(ctx context.Context, p schemas.Project) 
 			if re.MatchString(glenv.Name) {
 				env := schemas.Environment{
 					ProjectName:               p.Name,
+					ProjectID:                 p.ID,
 					ID:                        glenv.ID,
 					Name:                      glenv.Name,
 					OutputSparseStatusMetrics: p.OutputSparseStatusMetrics,

--- a/pkg/gitlab/projects.go
+++ b/pkg/gitlab/projects.go
@@ -135,6 +135,7 @@ func (c *Client) ListProjects(ctx context.Context, w config.Wildcard) ([]schemas
 			}
 
 			p := schemas.NewProject(gp.PathWithNamespace)
+			p.ID = gp.ID
 			p.ProjectParameters = w.ProjectParameters
 			projects = append(projects, p)
 		}

--- a/pkg/schemas/environments.go
+++ b/pkg/schemas/environments.go
@@ -8,6 +8,7 @@ import (
 // Environment ..
 type Environment struct {
 	ProjectName      string
+	ProjectID        int64
 	ID               int64
 	Name             string
 	ExternalURL      string
@@ -37,6 +38,7 @@ func (envs Environments) Count() int {
 func (e Environment) DefaultLabelsValues() map[string]string {
 	return map[string]string{
 		"project":     e.ProjectName,
+		"project_id":  strconv.FormatInt(e.ProjectID, 10),
 		"environment": e.Name,
 	}
 }

--- a/pkg/schemas/environments_test.go
+++ b/pkg/schemas/environments_test.go
@@ -25,11 +25,13 @@ func TestEnvironmentsCount(t *testing.T) {
 func TestEnvironmentDefaultLabelsValues(t *testing.T) {
 	e := Environment{
 		ProjectName: "foo",
+		ProjectID:   42,
 		Name:        "bar",
 	}
 
 	expectedValue := map[string]string{
 		"project":     "foo",
+		"project_id":  "42",
 		"environment": "bar",
 	}
 
@@ -39,6 +41,7 @@ func TestEnvironmentDefaultLabelsValues(t *testing.T) {
 func TestEnvironmentInformationLabelsValues(t *testing.T) {
 	e := Environment{
 		ProjectName: "foo",
+		ProjectID:   42,
 		Name:        "bar",
 		ID:          10,
 		ExternalURL: "http://genial",
@@ -53,6 +56,7 @@ func TestEnvironmentInformationLabelsValues(t *testing.T) {
 
 	expectedValue := map[string]string{
 		"project":                 "foo",
+		"project_id":              "42",
 		"environment":             "bar",
 		"environment_id":          "10",
 		"external_url":            "http://genial",

--- a/pkg/schemas/projects.go
+++ b/pkg/schemas/projects.go
@@ -11,6 +11,7 @@ import (
 type Project struct {
 	config.Project
 
+	ID     int64
 	Topics string
 }
 

--- a/pkg/schemas/ref.go
+++ b/pkg/schemas/ref.go
@@ -62,12 +62,13 @@ func (ref Ref) DefaultLabelsValues(input ...Pipeline) map[string]string {
 	}
 
 	return map[string]string{
-		"kind":      string(ref.Kind),
-		"project":   ref.Project.Name,
-		"ref":       ref.Name,
-		"topics":    ref.Project.Topics,
-		"variables": pipeline.Variables,
-		"source":    pipeline.Source,
+		"project":    ref.Project.Name,
+		"project_id": strconv.FormatInt(ref.Project.ID, 10),
+		"kind":       string(ref.Kind),
+		"ref":        ref.Name,
+		"topics":     ref.Project.Topics,
+		"variables":  pipeline.Variables,
+		"source":     pipeline.Source,
 	}
 }
 

--- a/pkg/schemas/ref_test.go
+++ b/pkg/schemas/ref_test.go
@@ -36,12 +36,13 @@ func TestRefDefaultLabelsValues(t *testing.T) {
 	}
 
 	expectedValue := map[string]string{
-		"kind":      "branch",
-		"project":   "foo/bar",
-		"ref":       "feature",
-		"topics":    "amazing,project",
-		"variables": "blah",
-		"source":    "schedule",
+		"project":    "foo/bar",
+		"project_id": "0",
+		"kind":       "branch",
+		"ref":        "feature",
+		"topics":     "amazing,project",
+		"variables":  "blah",
+		"source":     "schedule",
 	}
 
 	assert.Equal(t, expectedValue, ref.DefaultLabelsValues())


### PR DESCRIPTION
# Summary
Adds a `project_id` label alongside the existing `project` (path) label on all pipeline, job, environment, and test report metrics. This enables correlation with external systems that reference GitLab projects by their numeric ID.

When a project is loaded from configuration rather than discovered via the API, the ID is lazily resolved on first use and persisted in the store.

# Changes
The `project_id` label is added to `defaultLabels` and `environmentLabels` in the collectors. The `Project` and `Environment` schemas gain ID fields, and `DefaultLabelsValues()` emits the new label. A `resolveProjectID` helper fetches the ID from the GitLab API for config-defined projects. Webhook handlers propagate the project ID from event payloads. All existing tests are updated accordingly.

linked to this issue: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/issues/528

Made with the help of AI, tested locally with the quickstart on an actual gitlab instance

