### PR TITLE
feat(config): add maximum task execution time and GC duration metrics

### DIFF
--- a/docs/configuration_syntax.md
+++ b/docs/configuration_syntax.md
@@ -105,6 +105,10 @@ gitlab:
   # (optional, default: 1000)
   maximum_jobs_queue_size: 1000
 
+  # Time after which a task message is returned to the queue for reprocessing.
+  # Increase if GC tasks take longer than this to complete (default: 5m)
+  maximum_task_execution_time: 5m
+
 pull:
   projects_from_wildcards:
     # Whether to trigger a discovery or not when the

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -125,6 +125,11 @@ type Gitlab struct {
 	// - leverage webhooks instead of polling schedules
 	//
 	MaximumJobsQueueSize int `default:"1000" validate:"gte=10" yaml:"maximum_jobs_queue_size"`
+
+	// Time after which a task message reserved by a worker is returned to the queue
+	// for reprocessing. Increase this if long-running tasks (e.g. garbage collection)
+	// are being re-delivered before they complete.
+	MaximumTaskExecutionTime time.Duration `default:"5m" yaml:"maximum_task_execution_time"`
 }
 
 // Redis ..

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,6 +26,7 @@ func TestNew(t *testing.T) {
 	c.Gitlab.MaximumRequestsPerSecond = 1
 	c.Gitlab.BurstableRequestsPerSecond = 5
 	c.Gitlab.MaximumJobsQueueSize = 1000
+	c.Gitlab.MaximumTaskExecutionTime = 5 * time.Minute
 
 	c.Pull.ProjectsFromWildcards.OnInit = true
 	c.Pull.ProjectsFromWildcards.Scheduled = true

--- a/pkg/controller/collectors.go
+++ b/pkg/controller/collectors.go
@@ -13,6 +13,17 @@ var (
 	statusesList                 = [...]string{"created", "waiting_for_resource", "preparing", "pending", "running", "success", "failed", "canceled", "skipped", "manual", "scheduled", "error", "success_with_warnings"}
 )
 
+// NewInternalCollectorGCDurationSeconds returns a new collector for the gcpe_gc_duration_seconds metric.
+func NewInternalCollectorGCDurationSeconds() prometheus.Collector {
+	return prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gcpe_gc_duration_seconds",
+			Help: "Duration in seconds of the most recent garbage collection run",
+		},
+		[]string{"type"},
+	)
+}
+
 // NewInternalCollectorCurrentlyQueuedTasksCount returns a new collector for the gcpe_currently_queued_tasks_count metric.
 func NewInternalCollectorCurrentlyQueuedTasksCount() prometheus.Collector {
 	return prometheus.NewGaugeVec(

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -51,7 +51,7 @@ func New(ctx context.Context, cfg config.Config, version string) (c Controller, 
 		return
 	}
 
-	c.TaskController = NewTaskController(ctx, c.Redis, cfg.Gitlab.MaximumJobsQueueSize)
+	c.TaskController = NewTaskController(ctx, c.Redis, cfg.Gitlab.MaximumJobsQueueSize, cfg.Gitlab.MaximumTaskExecutionTime)
 	c.registerTasks()
 
 	var redisStore *store.Redis

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -13,6 +13,10 @@ import (
 	"github.com/mvisonneau/gitlab-ci-pipelines-exporter/pkg/store"
 )
 
+// gcDurationSeconds is a package-level singleton so that observations accumulate
+// across the transient Registry instances created on each /metrics scrape.
+var gcDurationSeconds = NewInternalCollectorGCDurationSeconds()
+
 // Registry wraps a pointer of prometheus.Registry.
 type Registry struct {
 	*prometheus.Registry
@@ -21,6 +25,7 @@ type Registry struct {
 		CurrentlyQueuedTasksCount  prometheus.Collector
 		EnvironmentsCount          prometheus.Collector
 		ExecutedTasksCount         prometheus.Collector
+		GCDurationSeconds          prometheus.Collector
 		GitLabAPIRequestsCount     prometheus.Collector
 		GitlabAPIRequestsRemaining prometheus.Collector
 		GitlabAPIRequestsLimit     prometheus.Collector
@@ -94,6 +99,7 @@ func (r *Registry) RegisterInternalCollectors() {
 	r.InternalCollectors.CurrentlyQueuedTasksCount = NewInternalCollectorCurrentlyQueuedTasksCount()
 	r.InternalCollectors.EnvironmentsCount = NewInternalCollectorEnvironmentsCount()
 	r.InternalCollectors.ExecutedTasksCount = NewInternalCollectorExecutedTasksCount()
+	r.InternalCollectors.GCDurationSeconds = gcDurationSeconds
 	r.InternalCollectors.GitLabAPIRequestsCount = NewInternalCollectorGitLabAPIRequestsCount()
 	r.InternalCollectors.GitlabAPIRequestsRemaining = NewInternalCollectorGitLabAPIRequestsRemaining()
 	r.InternalCollectors.GitlabAPIRequestsLimit = NewInternalCollectorGitLabAPIRequestsLimit()
@@ -104,6 +110,7 @@ func (r *Registry) RegisterInternalCollectors() {
 	_ = r.Register(r.InternalCollectors.CurrentlyQueuedTasksCount)
 	_ = r.Register(r.InternalCollectors.EnvironmentsCount)
 	_ = r.Register(r.InternalCollectors.ExecutedTasksCount)
+	_ = r.Register(r.InternalCollectors.GCDurationSeconds)
 	_ = r.Register(r.InternalCollectors.GitLabAPIRequestsCount)
 	_ = r.Register(r.InternalCollectors.GitlabAPIRequestsRemaining)
 	_ = r.Register(r.InternalCollectors.GitlabAPIRequestsLimit)

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 	"github.com/vmihailenco/taskq/memqueue/v4"
@@ -28,7 +29,7 @@ type TaskController struct {
 }
 
 // NewTaskController initializes and returns a new TaskController object.
-func NewTaskController(ctx context.Context, r *redis.Client, maximumJobsQueueSize int) (t TaskController) {
+func NewTaskController(ctx context.Context, r *redis.Client, maximumJobsQueueSize int, reservationTimeout time.Duration) (t TaskController) {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "controller:NewTaskController")
 	defer span.End()
 
@@ -39,6 +40,7 @@ func NewTaskController(ctx context.Context, r *redis.Client, maximumJobsQueueSiz
 		PauseErrorsThreshold: 3,
 		Handler:              t.TaskMap,
 		BufferSize:           maximumJobsQueueSize,
+		ReservationTimeout:   reservationTimeout,
 	}
 
 	if r != nil {
@@ -282,7 +284,11 @@ func (c *Controller) TaskHandlerGarbageCollectProjects(ctx context.Context) erro
 	defer c.unqueueTask(ctx, schemas.TaskTypeGarbageCollectProjects, "_")
 	defer c.TaskController.monitorLastTaskScheduling(schemas.TaskTypeGarbageCollectProjects)
 
-	return c.GarbageCollectProjects(ctx)
+	start := time.Now()
+	execErr := c.GarbageCollectProjects(ctx)
+	gcDurationSeconds.(*prometheus.GaugeVec).With(prometheus.Labels{"type": string(schemas.TaskTypeGarbageCollectProjects)}).Set(time.Since(start).Seconds())
+
+	return execErr
 }
 
 // TaskHandlerGarbageCollectEnvironments ..
@@ -290,7 +296,11 @@ func (c *Controller) TaskHandlerGarbageCollectEnvironments(ctx context.Context) 
 	defer c.unqueueTask(ctx, schemas.TaskTypeGarbageCollectEnvironments, "_")
 	defer c.TaskController.monitorLastTaskScheduling(schemas.TaskTypeGarbageCollectEnvironments)
 
-	return c.GarbageCollectEnvironments(ctx)
+	start := time.Now()
+	execErr := c.GarbageCollectEnvironments(ctx)
+	gcDurationSeconds.(*prometheus.GaugeVec).With(prometheus.Labels{"type": string(schemas.TaskTypeGarbageCollectEnvironments)}).Set(time.Since(start).Seconds())
+
+	return execErr
 }
 
 // TaskHandlerGarbageCollectRefs ..
@@ -298,7 +308,11 @@ func (c *Controller) TaskHandlerGarbageCollectRefs(ctx context.Context) error {
 	defer c.unqueueTask(ctx, schemas.TaskTypeGarbageCollectRefs, "_")
 	defer c.TaskController.monitorLastTaskScheduling(schemas.TaskTypeGarbageCollectRefs)
 
-	return c.GarbageCollectRefs(ctx)
+	start := time.Now()
+	execErr := c.GarbageCollectRefs(ctx)
+	gcDurationSeconds.(*prometheus.GaugeVec).With(prometheus.Labels{"type": string(schemas.TaskTypeGarbageCollectRefs)}).Set(time.Since(start).Seconds())
+
+	return execErr
 }
 
 // TaskHandlerGarbageCollectMetrics ..
@@ -306,7 +320,11 @@ func (c *Controller) TaskHandlerGarbageCollectMetrics(ctx context.Context) error
 	defer c.unqueueTask(ctx, schemas.TaskTypeGarbageCollectMetrics, "_")
 	defer c.TaskController.monitorLastTaskScheduling(schemas.TaskTypeGarbageCollectMetrics)
 
-	return c.GarbageCollectMetrics(ctx)
+	start := time.Now()
+	execErr := c.GarbageCollectMetrics(ctx)
+	gcDurationSeconds.(*prometheus.GaugeVec).With(prometheus.Labels{"type": string(schemas.TaskTypeGarbageCollectMetrics)}).Set(time.Since(start).Seconds())
+
+	return execErr
 }
 
 // Schedule ..


### PR DESCRIPTION
The task queue (vmihailenco/taskq with redisq backend) has a `ReservationTimeout` (default 5m). When a consumer holds a message longer than this timeout, redisq's internal `schedulePending()` goroutine considers the message abandoned, ACKs the old delivery, and re-enqueues it into the stream - while the original handler is still running.

More details I added to the [issue](https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/issues/1084).

To avoid that new configuration was created `maximum_task_execution_time` to a value well above the expected GC duration (e.g. 10m) in the configuration.

Also new metric was created gcpe_gc_duration_seconds (Duration in seconds of the most recent garbage collection run) that will help to monitor the current state