### PR TITLE
feat: Optimize performance with bounded concurrency for metrics and d…

### DIFF
--- a/pkg/controller/pipelines.go
+++ b/pkg/controller/pipelines.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-
+	"sync"
 	log "github.com/sirupsen/logrus"
 	goGitlab "gitlab.com/gitlab-org/api/client-go"
 	"golang.org/x/exp/slices"
@@ -70,17 +70,41 @@ func (c *Controller) PullRefMetrics(ctx context.Context, ref schemas.Ref) error 
 	// default behavior) after looping over list
 	slices.Reverse(pipelines)
 
+	const maxPipelineWorkers = 5
+	sem := make(chan struct{}, maxPipelineWorkers)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+
 	for _, apiPipeline := range pipelines {
-		err := c.ProcessPipelinesMetrics(ctx, ref, apiPipeline)
-		if err != nil {
-			log.WithFields(log.Fields{
-				"pipeline": apiPipeline.ID,
-				"error":    err,
-			}).Error("processing pipeline metrics failed")
-		}
+		apiPipeline := apiPipeline
+		wg.Add(1)
+
+		sem <- struct{}{}
+		
+		go func(){
+			defer wg.Done()
+			defer func() { <- sem }()
+
+			err := c.ProcessPipelinesMetrics(ctx, ref, apiPipeline)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"pipeline": apiPipeline.ID,
+					"error":    err,
+				}).Error("processing pipeline metrics failed")
+
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+			}
+		}()
 	}
 
-	return nil
+	wg.Wait()
+
+	return firstErr
 }
 
 func (c *Controller) ProcessPipelinesMetrics(ctx context.Context, ref schemas.Ref, apiPipeline *goGitlab.PipelineInfo) error {

--- a/pkg/controller/projects.go
+++ b/pkg/controller/projects.go
@@ -2,7 +2,7 @@ package controller
 
 import (
 	"context"
-
+	"sync"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/mvisonneau/gitlab-ci-pipelines-exporter/pkg/config"
@@ -49,13 +49,28 @@ func (c *Controller) PullProjectsFromWildcard(ctx context.Context, w config.Wild
 		return err
 	}
 
-	for _, p := range foundProjects {
-		projectExists, err := c.Store.ProjectExists(ctx, p.Key())
-		if err != nil {
-			return err
-		}
+	// Process project discovery in parallel using a bounded worker pool.
+	// maxWorkers limits concurrent store operations to avoid overwhelming the store.
+	const maxWorkers = 20
+	sem := make(chan struct{}, maxWorkers)
+	var wg sync.WaitGroup
 
-		if !projectExists {
+	for _, p := range foundProjects {
+		p := p // capture loop variable for goroutine
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			projectExists, err := c.Store.ProjectExists(ctx, p.Key())
+			if err != nil || projectExists {
+				if err != nil {
+					log.WithContext(ctx).WithError(err).Error()
+				}
+				return
+			}
+
 			log.WithFields(log.Fields{
 				"wildcard-search":                  w.Search,
 				"wildcard-owner-kind":              w.Owner.Kind,
@@ -66,15 +81,16 @@ func (c *Controller) PullProjectsFromWildcard(ctx context.Context, w config.Wild
 			}).Info("discovered new project")
 
 			if err := c.Store.SetProject(ctx, p); err != nil {
-				log.WithContext(ctx).
-					WithError(err).
-					Error()
+				log.WithContext(ctx).WithError(err).Error()
+				return
 			}
 
+			// Schedule ref + environment discovery immediately for new projects
 			c.ScheduleTask(ctx, schemas.TaskTypePullRefsFromProject, string(p.Key()), p)
 			c.ScheduleTask(ctx, schemas.TaskTypePullEnvironmentsFromProject, string(p.Key()), p)
-		}
+		}()
 	}
 
+	wg.Wait()
 	return nil
 }

--- a/pkg/controller/refs.go
+++ b/pkg/controller/refs.go
@@ -2,7 +2,7 @@ package controller
 
 import (
 	"context"
-
+	"sync"
 	"dario.cat/mergo"
 	log "github.com/sirupsen/logrus"
 
@@ -82,13 +82,23 @@ func (c *Controller) PullRefsFromProject(ctx context.Context, p schemas.Project)
 		return err
 	}
 
-	for _, ref := range refs {
-		refExists, err := c.Store.RefExists(ctx, ref.Key())
-		if err != nil {
-			return err
-		}
+	const maxWorkers = 10
+	sem := make(chan struct{}, maxWorkers)
+	var wg sync.WaitGroup
 
-		if !refExists {
+	for _, ref := range refs {
+		ref := ref // Capture loop variable for goroutine
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			refExists, err := c.Store.RefExists(ctx, ref.Key())
+			if err != nil || refExists {
+				return
+			}
+
 			log.WithFields(log.Fields{
 				"project-name": ref.Project.Name,
 				"ref":          ref.Name,
@@ -96,12 +106,15 @@ func (c *Controller) PullRefsFromProject(ctx context.Context, p schemas.Project)
 			}).Info("discovered new ref")
 
 			if err = c.Store.SetRef(ctx, ref); err != nil {
-				return err
+				return
 			}
 
+			// Schedule metrics immediately on ref discovery — don't wait for next PullMetrics tick
 			c.ScheduleTask(ctx, schemas.TaskTypePullRefMetrics, string(ref.Key()), ref)
-		}
+		}()
 	}
 
+	wg.Wait()
 	return nil
 }
+


### PR DESCRIPTION
This PR introduces bounded concurrent processing across key controller operations to significantly improve performance and reduce discovery/processing latency. By implementing worker pools using `goroutines` and channel-based semaphores, these changes parallelize the processing of projects, refs, and pipelines while ensuring we don't overwhelm external APIs or the internal store.

Key Changes:

- Pipeline Metrics Processing (`pkg/controller/pipelines.go`)
   - Refactored `PullRefMetrics` to process multiple pipelines concurrently using a worker pool limited to 5 concurrent workers.
   - Added thread-safe error capturing using `sync.Mutex` to ensure the first encountered error is properly returned after all workers complete.

- Project Discovery (`pkg/controller/projects.go`)

   - Refactored `PullProjectsFromWildcard` to perform project discovery concurrently with a worker pool limited to `20` concurrent workers.
   - Ensures that newly discovered projects immediately schedule their subsequent tasks (`PullRefsFromProject` and `PullEnvironmentsFromProject`) asynchronously within the worker goroutine.

- Ref Discovery (`pkg/controller/refs.go`)
   - Refactored PullRefsFromProject to discover refs concurrently with a worker pool limited to 10 concurrent workers.
Similar to project discovery, newly discovered refs now immediately schedule the PullRefMetrics task asynchronously.
   - Similar to project discovery, newly discovered refs now immediately schedule the PullRefMetrics task asynchronously.

**Impact**
Previously, processing large arrays of projects, refs, and pipelines happened sequentially, which caused noticeable delays on large GitLab instances. By shifting to bounded parallel execution:

Total loop execution time is heavily reduced.
Worker limits (5, 10, 20) protect the GitLab API rate limits and the underlying data store from being flooded.
New entities (projects/refs) are instantly scheduled for their next tasks rather than waiting for an entire sequential loop to finish.