### PR TITLE
fix(store): correct inverted Has{Project,Ref,Metric}Expired on Redis store

### DIFF
--- a/pkg/store/redis.go
+++ b/pkg/store/redis.go
@@ -539,13 +539,17 @@ func (r *Redis) ExecutedTasksCount(ctx context.Context) (uint64, error) {
 }
 
 // HasProjectExpired ..
+//
+// The TTL marker key is written with `Set ... EX <project_ttl>` whenever a
+// project is stored. While the key still exists the project is fresh; once
+// Redis has dropped it (TTL elapsed), the project is considered expired.
 func (r *Redis) HasProjectExpired(ctx context.Context, key schemas.ProjectKey) bool {
 	reply, err := r.Exists(ctx, getTTLProjectKey(key)).Result()
 	if err != nil {
 		return false
 	}
 
-	return reply > 0
+	return reply <= 0
 }
 
 func getTTLProjectKey(key schemas.ProjectKey) string {
@@ -553,13 +557,15 @@ func getTTLProjectKey(key schemas.ProjectKey) string {
 }
 
 // HasRefExpired ..
+//
+// See HasProjectExpired for the TTL-marker semantics.
 func (r *Redis) HasRefExpired(ctx context.Context, key schemas.RefKey) bool {
 	reply, err := r.Exists(ctx, getTTLRefKey(key)).Result()
 	if err != nil {
 		return false
 	}
 
-	return reply > 0
+	return reply <= 0
 }
 
 func getTTLRefKey(key schemas.RefKey) string {
@@ -567,13 +573,15 @@ func getTTLRefKey(key schemas.RefKey) string {
 }
 
 // HasMetricExpired ..
+//
+// See HasProjectExpired for the TTL-marker semantics.
 func (r *Redis) HasMetricExpired(ctx context.Context, key schemas.MetricKey) bool {
 	reply, err := r.Exists(ctx, getTTLMetricKey(key)).Result()
 	if err != nil {
 		return false
 	}
 
-	return reply > 0
+	return reply <= 0
 }
 
 func getTTLMetricKey(key schemas.MetricKey) string {

--- a/pkg/store/redis_test.go
+++ b/pkg/store/redis_test.go
@@ -297,6 +297,73 @@ func TestRedisUnqueueTask(t *testing.T) {
 	assert.Equal(t, uint64(1), count)
 }
 
+func newTestRedisStoreWithTTL(t *testing.T, ttl time.Duration) (*miniredis.Miniredis, *Redis) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+
+	t.Cleanup(func() {
+		mr.Close()
+	})
+
+	r := NewRedisStore(
+		redis.NewClient(&redis.Options{Addr: mr.Addr()}),
+		WithTTLConfig(&RedisTTLConfig{Project: ttl, Ref: ttl, Metric: ttl}),
+	)
+
+	return mr, r
+}
+
+func TestRedisHasProjectExpired(t *testing.T) {
+	ttl := time.Hour
+	mr, r := newTestRedisStoreWithTTL(t, ttl)
+
+	p := schemas.NewProject("foo/bar")
+	assert.NoError(t, r.SetProject(testCtx, p))
+
+	// A freshly written project must not be reported as expired.
+	assert.False(t, r.HasProjectExpired(testCtx, p.Key()))
+
+	// Once the TTL marker has elapsed, the project must be reported as expired.
+	mr.FastForward(ttl + time.Second)
+	assert.True(t, r.HasProjectExpired(testCtx, p.Key()))
+}
+
+func TestRedisHasRefExpired(t *testing.T) {
+	ttl := time.Hour
+	mr, r := newTestRedisStoreWithTTL(t, ttl)
+
+	ref := schemas.Ref{
+		Kind:    schemas.RefKindBranch,
+		Project: schemas.NewProject("foo/bar"),
+		Name:    "main",
+	}
+	assert.NoError(t, r.SetRef(testCtx, ref))
+
+	assert.False(t, r.HasRefExpired(testCtx, ref.Key()))
+
+	mr.FastForward(ttl + time.Second)
+	assert.True(t, r.HasRefExpired(testCtx, ref.Key()))
+}
+
+func TestRedisHasMetricExpired(t *testing.T) {
+	ttl := time.Hour
+	mr, r := newTestRedisStoreWithTTL(t, ttl)
+
+	m := schemas.Metric{
+		Kind:   schemas.MetricKindCoverage,
+		Labels: prometheus.Labels{"project": "foo/bar"},
+		Value:  5,
+	}
+	assert.NoError(t, r.SetMetric(testCtx, m))
+
+	assert.False(t, r.HasMetricExpired(testCtx, m.Key()))
+
+	mr.FastForward(ttl + time.Second)
+	assert.True(t, r.HasMetricExpired(testCtx, m.Key()))
+}
+
 func TestRedisCurrentlyQueuedTasksCount(t *testing.T) {
 	_, r := newTestRedisStore(t)
 


### PR DESCRIPTION
## Summary

Fixes #1087.

The Redis-backed `Has{Project,Ref,Metric}Expired` helpers compared with `reply > 0`, returning `true` *while* the TTL marker key still existed and `false` *after* Redis had dropped it — the opposite of what the GC loop expects. The GC deletes objects with reason `"expired"` when these helpers return `true`, so freshly-stored objects were wiped on the very next GC sweep and stale objects were kept indefinitely.

In webhook-only deployments the symptom is a near-empty pipeline metrics output: every webhook re-creates the metric, then the next GC cycle (default `garbage_collect.metrics.interval_seconds: 600`) deletes it. We see this on a 180-project deployment where `gcpe_projects_count = 180` but `gitlab_ci_pipeline_id` only has series for whichever 1–2 refs received a webhook in the last 10 minutes.

The local in-memory store hard-codes `false` for these helpers and is unaffected.

## Change

Flip the comparisons to `reply <= 0` in all three Redis helpers — an object is considered expired exactly when its TTL marker has been removed by Redis. Doc-comment added explaining the marker semantics.

## Test plan

- [x] Added `TestRedisHas{Project,Ref,Metric}Expired` using `miniredis.FastForward` — each test fails on the unpatched code at both halves (fresh-not-expired right after Set, expired-after-FastForward) and passes after the fix.
- [x] `go test ./...` — full suite green.
- [x] `go vet ./...` — clean.