### PR TITLE
fix(redis): suppress unsupported CLIENT subcommands for Elasticache compatibility

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,6 +133,18 @@ type Redis struct {
 	// format: redis[s]://[:password@]host[:port][/db-number][?option=value])
 	URL string `yaml:"url"`
 
+	// DisableIdentity suppresses the CLIENT SETINFO and CLIENT MAINT_NOTIFICATIONS
+	// commands that go-redis v9 sends during connection initialisation.
+	// CLIENT SETINFO requires Redis 7.2.0+ and is not supported by AWS
+	// Elasticache (which ships Redis 7.1.x) or other Redis-compatible services
+	// that have not yet implemented it. Sending unsupported CLIENT subcommands
+	// during init causes subsequent commands (such as PING) to read a stale
+	// error response, producing spurious "NOAUTH" failures even when
+	// credentials are correct. Set this to true when targeting AWS Elasticache
+	// or any Redis-compatible service that does not support CLIENT SETINFO.
+	// See also: https://github.com/redis/go-redis/issues/2911
+	DisableIdentity bool `default:"false" yaml:"disable_identity"`
+
 	ProjectTTL time.Duration `default:"168h" yaml:"project_ttl"`
 	RefTTL     time.Duration `default:"1h" yaml:"ref_ttl"`
 	MetricTTL  time.Duration `default:"1h" yaml:"metric_ttl"`

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -50,6 +50,7 @@ gitlab:
 
 redis:
   url: redis://popopo:1337
+  disable_identity: true
 
 pull:
   projects_from_wildcards:
@@ -174,6 +175,7 @@ wildcards:
 	xcfg.Gitlab.MaximumRequestsPerSecond = 2
 
 	xcfg.Redis.URL = "redis://popopo:1337"
+	xcfg.Redis.DisableIdentity = true
 
 	xcfg.Pull.ProjectsFromWildcards.OnInit = false
 	xcfg.Pull.ProjectsFromWildcards.Scheduled = false

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/redis/go-redis/extra/redisotel/v9"
 	"github.com/redis/go-redis/v9"
+	"github.com/redis/go-redis/v9/maintnotifications"
 	log "github.com/sirupsen/logrus"
 	"github.com/vmihailenco/taskq/v4"
 	"go.opentelemetry.io/otel"
@@ -194,6 +195,20 @@ func (c *Controller) configureRedis(ctx context.Context, config *config.Redis) (
 
 	if opt, err = redis.ParseURL(config.URL); err != nil {
 		return
+	}
+
+	// AWS Elasticache (Redis 7.1.x) and other Redis-compatible services that
+	// predate Redis 7.2.0 do not support CLIENT SETINFO. go-redis v9 also
+	// sends CLIENT MAINT_NOTIFICATIONS, which is Redis Cloud-specific.
+	// Sending unsupported CLIENT subcommands during connection init causes
+	// subsequent commands to read a stale error response, producing spurious
+	// "NOAUTH" failures even when credentials are correct.
+	// disable_identity suppresses both commands. See go-redis issue #2911.
+	if config.DisableIdentity {
+		opt.DisableIdentity = true
+		opt.MaintNotificationsConfig = &maintnotifications.Config{
+			Mode: maintnotifications.ModeDisabled,
+		}
 	}
 
 	c.Redis = redis.NewClient(opt)


### PR DESCRIPTION
AWS Elasticache (Redis 7.1.x) does not support `CLIENT SETINFO` (added in
Redis 7.2.0) or `CLIENT MAINT_NOTIFICATIONS` (Redis Cloud-specific). go-redis
v9 sends both during connection initialisation; receiving an error mid-init
causes the subsequent `PING` to read a stale error response off the wire,
producing spurious `NOAUTH` failures even when credentials are correct.

Adds a `redis.disable_identity` config flag that sets `opt.DisableIdentity`
and disables `MaintNotificationsConfig` on the go-redis client, suppressing
both commands. Existing behaviour is unchanged when the flag is not set.

See: https://github.com/redis/go-redis/issues/2911

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
