### PR TITLE
Support GitLab merge train refs

### DIFF
--- a/pkg/controller/pipelines.go
+++ b/pkg/controller/pipelines.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 
 	log "github.com/sirupsen/logrus"
 	goGitlab "gitlab.com/gitlab-org/api/client-go"
@@ -26,31 +27,20 @@ func (c *Controller) PullRefMetrics(ctx context.Context, ref schemas.Ref) error 
 		"ref-kind":     ref.Kind,
 	}
 
-	// We need a different syntax if the ref is a merge-request
-	var refName string
+	refNames := []string{ref.Name}
 	if ref.Kind == schemas.RefKindMergeRequest {
-		refName = fmt.Sprintf("refs/merge-requests/%s/head", ref.Name)
-	} else {
-		refName = ref.Name
+		refNames = []string{
+			fmt.Sprintf("refs/merge-requests/%s/head", ref.Name),
+			fmt.Sprintf("refs/merge-requests/%s/merge", ref.Name),
+			fmt.Sprintf("refs/merge-requests/%s/train", ref.Name),
+		}
 	}
 
-	pipelines, _, err := c.Gitlab.GetProjectPipelines(ctx, ref.Project.Name, &goGitlab.ListProjectPipelinesOptions{
-		ListOptions: goGitlab.ListOptions{
-			PerPage: int64(ref.Project.Pull.Pipeline.PerRef),
-			Page:    1,
-		},
-		Ref: &refName,
-	})
-	if err != nil {
-		return fmt.Errorf("error fetching project pipelines for %s: %v", ref.Project.Name, err)
-	}
-
-	if len(pipelines) == 0 && ref.Kind == schemas.RefKindMergeRequest {
-		refName = fmt.Sprintf("refs/merge-requests/%s/merge", ref.Name)
-		pipelines, _, err = c.Gitlab.GetProjectPipelines(ctx, ref.Project.Name, &goGitlab.ListProjectPipelinesOptions{
-			// We only need the most recent pipeline
+	var pipelines []*goGitlab.PipelineInfo
+	for _, refName := range refNames {
+		refPipelines, _, err := c.Gitlab.GetProjectPipelines(ctx, ref.Project.Name, &goGitlab.ListProjectPipelinesOptions{
 			ListOptions: goGitlab.ListOptions{
-				PerPage: 1,
+				PerPage: int64(ref.Project.Pull.Pipeline.PerRef),
 				Page:    1,
 			},
 			Ref: &refName,
@@ -58,6 +48,8 @@ func (c *Controller) PullRefMetrics(ctx context.Context, ref schemas.Ref) error 
 		if err != nil {
 			return fmt.Errorf("error fetching project pipelines for %s: %v", ref.Project.Name, err)
 		}
+
+		pipelines = append(pipelines, refPipelines...)
 	}
 
 	if len(pipelines) == 0 {
@@ -66,9 +58,11 @@ func (c *Controller) PullRefMetrics(ctx context.Context, ref schemas.Ref) error 
 		return nil
 	}
 
-	// Reverse result list to have `ref`'s `LatestPipeline` untouched (compared to
-	// default behavior) after looping over list
-	slices.Reverse(pipelines)
+	// Process pipelines from oldest to newest so the newest pipeline remains the ref's LatestPipeline.
+	// For merge requests, this also lets active merge-train pipelines supersede stale head/merge pipelines.
+	sort.SliceStable(pipelines, func(i, j int) bool {
+		return pipelineInfoBefore(pipelines[i], pipelines[j])
+	})
 
 	for _, apiPipeline := range pipelines {
 		err := c.ProcessPipelinesMetrics(ctx, ref, apiPipeline)
@@ -81,6 +75,18 @@ func (c *Controller) PullRefMetrics(ctx context.Context, ref schemas.Ref) error 
 	}
 
 	return nil
+}
+
+func pipelineInfoBefore(a, b *goGitlab.PipelineInfo) bool {
+	if a.UpdatedAt != nil && b.UpdatedAt != nil && !a.UpdatedAt.Equal(*b.UpdatedAt) {
+		return a.UpdatedAt.Before(*b.UpdatedAt)
+	}
+
+	if a.CreatedAt != nil && b.CreatedAt != nil && !a.CreatedAt.Equal(*b.CreatedAt) {
+		return a.CreatedAt.Before(*b.CreatedAt)
+	}
+
+	return a.ID < b.ID
 }
 
 func (c *Controller) ProcessPipelinesMetrics(ctx context.Context, ref schemas.Ref, apiPipeline *goGitlab.PipelineInfo) error {

--- a/pkg/controller/pipelines_test.go
+++ b/pkg/controller/pipelines_test.go
@@ -385,8 +385,14 @@ func TestPullRefMetricsMergeRequestPipeline(t *testing.T) {
 
 	mux.HandleFunc("/api/v4/projects/foo/pipelines",
 		func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "refs/merge-requests/1234/head", r.URL.Query().Get("ref"))
-			_, _ = fmt.Fprint(w, `[{"id":1}]`)
+			switch r.URL.Query().Get("ref") {
+			case "refs/merge-requests/1234/head":
+				_, _ = fmt.Fprint(w, `[{"id":1}]`)
+			case "refs/merge-requests/1234/merge", "refs/merge-requests/1234/train":
+				_, _ = fmt.Fprint(w, `[]`)
+			default:
+				assert.Failf(t, "unexpected ref", "%s", r.URL.Query().Get("ref"))
+			}
 		})
 
 	mux.HandleFunc("/api/v4/projects/foo/pipelines/1",
@@ -411,4 +417,59 @@ func TestPullRefMetricsMergeRequestPipeline(t *testing.T) {
 			schemas.RefKindMergeRequest,
 			"1234",
 		)))
+}
+
+func TestPullRefMetricsMergeRequestPipelineUsesNewestTrainPipeline(t *testing.T) {
+	ctx, c, mux, srv := newTestController(config.Config{})
+	defer srv.Close()
+
+	mux.HandleFunc("/api/v4/projects/foo/pipelines",
+		func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Query().Get("ref") {
+			case "refs/merge-requests/1234/head":
+				_, _ = fmt.Fprint(w, `[{"id":1,"updated_at":"2016-08-11T11:28:34.085Z"}]`)
+			case "refs/merge-requests/1234/merge":
+				_, _ = fmt.Fprint(w, `[]`)
+			case "refs/merge-requests/1234/train":
+				_, _ = fmt.Fprint(w, `[{"id":2,"updated_at":"2016-08-11T11:29:34.085Z"}]`)
+			default:
+				assert.Failf(t, "unexpected ref", "%s", r.URL.Query().Get("ref"))
+			}
+		})
+
+	mux.HandleFunc("/api/v4/projects/foo/pipelines/1",
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = fmt.Fprint(w, `{"id":1,"updated_at":"2016-08-11T11:28:34.085Z","duration":300,"status":"success","coverage":"30.2","source":"schedule"}`)
+		})
+
+	mux.HandleFunc("/api/v4/projects/foo/pipelines/2",
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = fmt.Fprint(w, `{"id":2,"updated_at":"2016-08-11T11:29:34.085Z","duration":300,"status":"running","coverage":"30.2","source":"schedule"}`)
+		})
+
+	p := schemas.NewProject("foo")
+
+	assert.NoError(t, c.PullRefMetrics(
+		ctx,
+		schemas.NewRef(
+			p,
+			schemas.RefKindMergeRequest,
+			"1234",
+		)))
+
+	metrics, _ := c.Store.Metrics(ctx)
+	labels := map[string]string{
+		"kind":      "merge-request",
+		"project":   "foo",
+		"ref":       "1234",
+		"topics":    "",
+		"variables": "",
+		"source":    "schedule",
+	}
+	runID := schemas.Metric{
+		Kind:   schemas.MetricKindID,
+		Labels: labels,
+		Value:  2,
+	}
+	assert.Equal(t, runID, metrics[runID.Key()])
 }

--- a/pkg/schemas/ref.go
+++ b/pkg/schemas/ref.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	mergeRequestRegexp string = `^((\d+)|refs/merge-requests/(\d+)/(?:head|merge))$`
+	mergeRequestRegexp string = `^((\d+)|refs/merge-requests/(\d+)/(?:head|merge|train))$`
 
 	// RefKindBranch refers to a branch.
 	RefKindBranch RefKind = "branch"

--- a/pkg/schemas/ref_test.go
+++ b/pkg/schemas/ref_test.go
@@ -81,6 +81,10 @@ func TestGetMergeRequestIIDFromRefName(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "5678", name)
 
+	name, err = GetMergeRequestIIDFromRefName("refs/merge-requests/5678/train")
+	assert.NoError(t, err)
+	assert.Equal(t, "5678", name)
+
 	name, err = GetMergeRequestIIDFromRefName("20.0.1")
 	assert.Error(t, err)
 	assert.Equal(t, "20.0.1", name)


### PR DESCRIPTION
## Summary

- recognise `refs/merge-requests/<iid>/train` as a merge request ref
- query merge request pipelines from `/head`, `/merge`, and `/train`
- process candidate MR pipelines oldest-to-newest so the latest train pipeline can supersede stale head/merge pipelines
- add tests for merge train ref parsing and selecting the newest train pipeline

Fixes #1091.

## Tests

```sh
go test ./...
```
