### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/examples/ha-setup/docker-compose.yml
+++ b/examples/ha-setup/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.8'
 services:
   redis:
-    image: docker.io/bitnami/redis:6.2
+    image: docker.io/soldevelo/redis:6.2
     ports:
       - 6379:6379
     environment:

--- a/examples/opentelemetry/docker-compose.yml
+++ b/examples/opentelemetry/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.8'
 services:
   redis:
-    image: docker.io/bitnami/redis:6.2
+    image: docker.io/soldevelo/redis:6.2
     ports:
       - 6379:6379
     environment:


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/redis:6.2` → [`soldevelo/redis:6.2`](https://hub.docker.com/r/soldevelo/redis)