### PR TITLE
fix(webhooks): stop dropping webhook events for tasks already in flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [0ver](https://0ver.org) (more or less).
 
 ## [Unreleased]
 
+* fix: a pipeline/job/deployment webhook received while a pull for the same ref/environment was already in flight is now coalesced into a rescheduled pull instead of being silently dropped, which previously could leave a `running` pipeline status metric stuck forever
+
 ## [v0.5.10] - 2025-01-14
 
 * fix(deps): update module google.golang.org/grpc to v1.67.1 by @renovate in https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/pull/904

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -99,8 +99,14 @@ func (c *Controller) registerTasks() {
 	}
 }
 
-func (c *Controller) unqueueTask(ctx context.Context, tt schemas.TaskType, uniqueID string) {
-	if err := c.Store.UnqueueTask(ctx, tt, uniqueID); err != nil {
+// unqueueTask releases the task lock and reports whether the task was marked
+// dirty while it ran, ie. whether it should be rescheduled since its inputs may
+// have changed since the in-flight execution started (see webhooks.go, where
+// pipeline/job events for a ref that is already being pulled are coalesced this
+// way instead of being dropped).
+func (c *Controller) unqueueTask(ctx context.Context, tt schemas.TaskType, uniqueID string) (requeue bool) {
+	requeue, err := c.Store.UnqueueTask(ctx, tt, uniqueID)
+	if err != nil {
 		log.WithContext(ctx).
 			WithFields(log.Fields{
 				"task_type":      tt,
@@ -109,6 +115,8 @@ func (c *Controller) unqueueTask(ctx context.Context, tt schemas.TaskType, uniqu
 			WithError(err).
 			Warn("unqueuing task")
 	}
+
+	return
 }
 
 func configureTracing(ctx context.Context, grpcEndpoint string) error {

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -104,7 +104,14 @@ func (c *Controller) TaskHandlerPullEnvironmentsFromProject(ctx context.Context,
 
 // TaskHandlerPullEnvironmentMetrics ..
 func (c *Controller) TaskHandlerPullEnvironmentMetrics(ctx context.Context, env schemas.Environment) {
-	defer c.unqueueTask(ctx, schemas.TaskTypePullEnvironmentMetrics, string(env.Key()))
+	defer func() {
+		// If a deployment event for this environment came in while we were pulling,
+		// it was coalesced into this run rather than dropped: reschedule a pull to
+		// pick up the state it carried.
+		if c.unqueueTask(ctx, schemas.TaskTypePullEnvironmentMetrics, string(env.Key())) {
+			c.ScheduleTask(context.Background(), schemas.TaskTypePullEnvironmentMetrics, string(env.Key()), env)
+		}
+	}()
 
 	// On errors, we do not want to retry these tasks
 	if err := c.PullEnvironmentMetrics(ctx, env); err != nil {
@@ -136,7 +143,16 @@ func (c *Controller) TaskHandlerPullRefsFromProject(ctx context.Context, p schem
 
 // TaskHandlerPullRefMetrics ..
 func (c *Controller) TaskHandlerPullRefMetrics(ctx context.Context, ref schemas.Ref) {
-	defer c.unqueueTask(ctx, schemas.TaskTypePullRefMetrics, string(ref.Key()))
+	defer func() {
+		// If a pipeline/job webhook for this ref came in while we were pulling, it
+		// was coalesced into this run rather than dropped: reschedule a pull to
+		// pick up the state it carried (eg. a "success" webhook received while a
+		// "running" pull was still in flight must not be lost, or the ref's status
+		// metric would be stuck on "running" forever).
+		if c.unqueueTask(ctx, schemas.TaskTypePullRefMetrics, string(ref.Key())) {
+			c.ScheduleTask(context.Background(), schemas.TaskTypePullRefMetrics, string(ref.Key()), ref)
+		}
+	}()
 
 	// On errors, we do not want to retry these tasks
 	if err := c.PullRefMetrics(ctx, ref); err != nil {
@@ -394,9 +410,11 @@ func (c *Controller) ScheduleTask(ctx context.Context, tt schemas.TaskType, uniq
 	}
 
 	if qlen >= c.TaskController.Queue.Options().BufferSize {
+		// This is a silent data loss, not a transient condition: the task is
+		// dropped and nothing will retry it (see gitlab.maximum_jobs_queue_size).
 		log.WithContext(ctx).
 			WithFields(logFields).
-			Warn("queue buffer size exhausted, skipping scheduling of task..")
+			Error("queue buffer size exhausted, skipping scheduling of task..")
 
 		return
 	}

--- a/pkg/controller/scheduler_test.go
+++ b/pkg/controller/scheduler_test.go
@@ -1,3 +1,88 @@
 package controller
 
-// TODO
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mvisonneau/gitlab-ci-pipelines-exporter/pkg/config"
+	"github.com/mvisonneau/gitlab-ci-pipelines-exporter/pkg/schemas"
+)
+
+// TestTaskHandlerPullRefMetricsRequeuesWhenDirty ensures that if a pipeline/job
+// webhook for a ref arrives while a pull for that same ref is already in flight,
+// it gets coalesced into a rescheduled pull instead of being silently dropped --
+// which is what previously left "running" pipelines stuck forever (the ref's
+// status metric would never be updated again once the in-flight pull completed).
+func TestTaskHandlerPullRefMetricsRequeuesWhenDirty(t *testing.T) {
+	ctx, c, mux, srv := newTestController(config.Config{})
+	defer srv.Close()
+
+	mux.HandleFunc("/api/v4/projects/foo/pipelines",
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = fmt.Fprint(w, `[{"id":1}]`)
+		})
+
+	mux.HandleFunc("/api/v4/projects/foo/pipelines/1",
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = fmt.Fprint(w, `{"id":1,"created_at":"2016-08-11T11:27:00.085Z",
+			"started_at":"2016-08-11T11:28:00.085Z","duration":300,"queued_duration":60,
+			"status":"running","source":"schedule"}`)
+		})
+
+	ref := schemas.NewRef(schemas.NewProject("foo"), schemas.RefKindBranch, "bar")
+
+	// Simulate the race: ScheduleTask locks the ref for a first pull, then a
+	// second webhook comes in for the same ref while that pull is still running.
+	ok, err := c.Store.QueueTask(ctx, schemas.TaskTypePullRefMetrics, string(ref.Key()), c.UUID.String())
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = c.Store.QueueTask(ctx, schemas.TaskTypePullRefMetrics, string(ref.Key()), c.UUID.String())
+	assert.NoError(t, err)
+	assert.False(t, ok, "second call should find the task already queued/running")
+
+	// Run the (first) pull to completion.
+	c.TaskHandlerPullRefMetrics(ctx, ref)
+
+	// The handler must have detected the dirty flag left by the second call and
+	// rescheduled a pull, which re-acquires the lock synchronously before the
+	// task is actually re-run.
+	ok, err = c.Store.QueueTask(ctx, schemas.TaskTypePullRefMetrics, string(ref.Key()), c.UUID.String())
+	assert.NoError(t, err)
+	assert.False(t, ok, "expected the ref pull to have been rescheduled and thus still locked")
+}
+
+// TestTaskHandlerPullEnvironmentMetricsRequeuesWhenDirty mirrors
+// TestTaskHandlerPullRefMetricsRequeuesWhenDirty for deployment webhooks.
+func TestTaskHandlerPullEnvironmentMetricsRequeuesWhenDirty(t *testing.T) {
+	ctx, c, mux, srv := newTestController(config.Config{})
+	defer srv.Close()
+
+	mux.HandleFunc("/api/v4/projects/foo/environments/1",
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = fmt.Fprint(w, `{"id":1,"name":"prod","external_url":"https://foo.example.com","state":"available"}`)
+		})
+
+	env := schemas.Environment{
+		ProjectName: "foo",
+		Name:        "prod",
+		ID:          1,
+	}
+
+	ok, err := c.Store.QueueTask(ctx, schemas.TaskTypePullEnvironmentMetrics, string(env.Key()), c.UUID.String())
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = c.Store.QueueTask(ctx, schemas.TaskTypePullEnvironmentMetrics, string(env.Key()), c.UUID.String())
+	assert.NoError(t, err)
+	assert.False(t, ok, "second call should find the task already queued/running")
+
+	c.TaskHandlerPullEnvironmentMetrics(ctx, env)
+
+	ok, err = c.Store.QueueTask(ctx, schemas.TaskTypePullEnvironmentMetrics, string(env.Key()), c.UUID.String())
+	assert.NoError(t, err)
+	assert.False(t, ok, "expected the environment pull to have been rescheduled and thus still locked")
+}

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -30,6 +30,8 @@ type Local struct {
 	tasks              schemas.Tasks
 	tasksMutex         sync.RWMutex
 	executedTasksCount uint64
+
+	dirtyTasks map[schemas.TaskType]map[string]struct{}
 }
 
 // HasProjectExpired ..
@@ -394,7 +396,9 @@ func (l *Local) isTaskAlreadyQueued(tt schemas.TaskType, uniqueID string) bool {
 }
 
 // QueueTask registers that we are queueing the task.
-// It returns true if it managed to schedule it, false if it was already scheduled.
+// It returns true if it managed to schedule it, false if it was already scheduled,
+// in which case the ongoing execution is marked dirty so that UnqueueTask reports
+// it should be rescheduled once done.
 func (l *Local) QueueTask(_ context.Context, tt schemas.TaskType, uniqueID, _ string) (bool, error) {
 	if !l.isTaskAlreadyQueued(tt, uniqueID) {
 		l.tasksMutex.Lock()
@@ -405,11 +409,26 @@ func (l *Local) QueueTask(_ context.Context, tt schemas.TaskType, uniqueID, _ st
 		return true, nil
 	}
 
+	l.tasksMutex.Lock()
+	defer l.tasksMutex.Unlock()
+
+	if l.dirtyTasks == nil {
+		l.dirtyTasks = make(map[schemas.TaskType]map[string]struct{})
+	}
+
+	if l.dirtyTasks[tt] == nil {
+		l.dirtyTasks[tt] = make(map[string]struct{})
+	}
+
+	l.dirtyTasks[tt][uniqueID] = struct{}{}
+
 	return false, nil
 }
 
-// UnqueueTask removes the task from the tracker.
-func (l *Local) UnqueueTask(_ context.Context, tt schemas.TaskType, uniqueID string) error {
+// UnqueueTask removes the task from the tracker. It returns true if the task was
+// marked dirty while it was queued/running, meaning it should be rescheduled since
+// its inputs may have changed since the in-flight execution started.
+func (l *Local) UnqueueTask(_ context.Context, tt schemas.TaskType, uniqueID string) (requeue bool, err error) {
 	if l.isTaskAlreadyQueued(tt, uniqueID) {
 		l.tasksMutex.Lock()
 		defer l.tasksMutex.Unlock()
@@ -417,9 +436,17 @@ func (l *Local) UnqueueTask(_ context.Context, tt schemas.TaskType, uniqueID str
 		delete(l.tasks[tt], uniqueID)
 
 		l.executedTasksCount++
+
+		if l.dirtyTasks[tt] != nil {
+			if _, dirty := l.dirtyTasks[tt][uniqueID]; dirty {
+				delete(l.dirtyTasks[tt], uniqueID)
+
+				requeue = true
+			}
+		}
 	}
 
-	return nil
+	return
 }
 
 // CurrentlyQueuedTasksCount ..

--- a/pkg/store/local_test.go
+++ b/pkg/store/local_test.go
@@ -242,8 +242,37 @@ func TestLocalUnqueueTask(t *testing.T) {
 	l := NewLocalStore()
 	_, _ = l.QueueTask(testCtx, schemas.TaskTypePullMetrics, "foo", "")
 	assert.Equal(t, uint64(0), l.(*Local).executedTasksCount)
-	assert.NoError(t, l.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo"))
+	requeue, err := l.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
+	assert.NoError(t, err)
+	assert.False(t, requeue)
 	assert.Equal(t, uint64(1), l.(*Local).executedTasksCount)
+}
+
+func TestLocalUnqueueTaskRequeuesWhenDirty(t *testing.T) {
+	l := NewLocalStore()
+
+	// First caller wins the lock.
+	ok, err := l.QueueTask(testCtx, schemas.TaskTypePullMetrics, "foo", "")
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	// Second caller finds it already queued and marks it dirty.
+	ok, err = l.QueueTask(testCtx, schemas.TaskTypePullMetrics, "foo", "")
+	assert.False(t, ok)
+	assert.NoError(t, err)
+
+	// Unqueueing must report that a reschedule is needed.
+	requeue, err := l.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
+	assert.NoError(t, err)
+	assert.True(t, requeue)
+
+	// The dirty flag is consumed: a second unqueue does not request another reschedule.
+	ok, _ = l.QueueTask(testCtx, schemas.TaskTypePullMetrics, "foo", "")
+	assert.True(t, ok)
+
+	requeue, err = l.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
+	assert.NoError(t, err)
+	assert.False(t, requeue)
 }
 
 func TestLocalCurrentlyQueuedTasksCount(t *testing.T) {
@@ -254,7 +283,8 @@ func TestLocalCurrentlyQueuedTasksCount(t *testing.T) {
 
 	count, _ := l.CurrentlyQueuedTasksCount(testCtx)
 	assert.Equal(t, uint64(3), count)
-	assert.NoError(t, l.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo"))
+	_, err := l.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
+	assert.NoError(t, err)
 	count, _ = l.CurrentlyQueuedTasksCount(testCtx)
 	assert.Equal(t, uint64(2), count)
 }
@@ -263,8 +293,8 @@ func TestLocalExecutedTasksCount(t *testing.T) {
 	l := NewLocalStore()
 	_, _ = l.QueueTask(testCtx, schemas.TaskTypePullMetrics, "foo", "")
 	_, _ = l.QueueTask(testCtx, schemas.TaskTypePullMetrics, "bar", "")
-	_ = l.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
-	_ = l.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
+	_, _ = l.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
+	_, _ = l.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
 
 	count, _ := l.ExecutedTasksCount(testCtx)
 	assert.Equal(t, uint64(1), count)

--- a/pkg/store/redis.go
+++ b/pkg/store/redis.go
@@ -458,8 +458,16 @@ func getRedisQueueKey(tt schemas.TaskType, taskUUID string) string {
 	return fmt.Sprintf("%s:%v:%s", redisTaskKey, tt, taskUUID)
 }
 
+func getRedisDirtyTaskKey(tt schemas.TaskType, taskUUID string) string {
+	// Deliberately not prefixed with "task:" so it does not get picked up by the
+	// `task:*` SCAN used by CurrentlyQueuedTasksCount.
+	return fmt.Sprintf("dirtyTask:%v:%s", tt, taskUUID)
+}
+
 // QueueTask registers that we are queueing the task.
-// It returns true if it managed to schedule it, false if it was already scheduled.
+// It returns true if it managed to schedule it, false if it was already scheduled,
+// in which case the ongoing execution is marked dirty so that UnqueueTask reports
+// it should be rescheduled once done.
 func (r *Redis) QueueTask(ctx context.Context, tt schemas.TaskType, taskUUID, processUUID string) (set bool, err error) {
 	k := getRedisQueueKey(tt, taskUUID)
 
@@ -495,11 +503,19 @@ func (r *Redis) QueueTask(ctx context.Context, tt schemas.TaskType, taskUUID, pr
 		}
 	}
 
-	return
+	// The lock is legitimately held by a live process (possibly this one), meaning
+	// a task for this exact uniqueID is already queued or running. Mark it dirty so
+	// the in-flight execution gets rescheduled once it completes, instead of silently
+	// dropping this request.
+	_, err = r.Set(ctx, getRedisDirtyTaskKey(tt, taskUUID), true, 0).Result()
+
+	return false, err
 }
 
-// UnqueueTask removes the task from the tracker.
-func (r *Redis) UnqueueTask(ctx context.Context, tt schemas.TaskType, taskUUID string) (err error) {
+// UnqueueTask removes the task from the tracker. It returns true if the task was
+// marked dirty while it was queued/running, meaning it should be rescheduled since
+// its inputs may have changed since the in-flight execution started.
+func (r *Redis) UnqueueTask(ctx context.Context, tt schemas.TaskType, taskUUID string) (requeue bool, err error) {
 	var matched int64
 
 	matched, err = r.Del(ctx, getRedisQueueKey(tt, taskUUID)).Result()
@@ -508,8 +524,18 @@ func (r *Redis) UnqueueTask(ctx context.Context, tt schemas.TaskType, taskUUID s
 	}
 
 	if matched > 0 {
-		_, err = r.Incr(ctx, redisTasksExecutedCountKey).Result()
+		if _, err = r.Incr(ctx, redisTasksExecutedCountKey).Result(); err != nil {
+			return
+		}
 	}
+
+	var dirtyDeleted int64
+
+	if dirtyDeleted, err = r.Del(ctx, getRedisDirtyTaskKey(tt, taskUUID)).Result(); err != nil {
+		return
+	}
+
+	requeue = dirtyDeleted > 0
 
 	return
 }

--- a/pkg/store/redis_test.go
+++ b/pkg/store/redis_test.go
@@ -292,9 +292,41 @@ func TestRedisUnqueueTask(t *testing.T) {
 	count, _ := r.ExecutedTasksCount(testCtx)
 	assert.Equal(t, uint64(0), count)
 
-	assert.NoError(t, r.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo"))
+	requeue, err := r.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
+	assert.NoError(t, err)
+	assert.False(t, requeue)
 	count, _ = r.ExecutedTasksCount(testCtx)
 	assert.Equal(t, uint64(1), count)
+}
+
+func TestRedisUnqueueTaskRequeuesWhenDirty(t *testing.T) {
+	_, r := newTestRedisStore(t)
+
+	// First caller wins the lock.
+	ok, err := r.QueueTask(testCtx, schemas.TaskTypePullMetrics, "foo", "controller1")
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	// A keepalive is required for the "still alive" branch to be exercised.
+	_, _ = r.(*Redis).SetKeepalive(testCtx, "controller1", time.Minute)
+
+	// Second caller (or a second webhook handled by the same controller) finds
+	// it already queued and marks it dirty instead of being dropped.
+	ok, err = r.QueueTask(testCtx, schemas.TaskTypePullMetrics, "foo", "controller1")
+	assert.False(t, ok)
+	assert.NoError(t, err)
+
+	requeue, err := r.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
+	assert.NoError(t, err)
+	assert.True(t, requeue)
+
+	// The dirty flag is consumed: a second unqueue does not request another reschedule.
+	ok, _ = r.QueueTask(testCtx, schemas.TaskTypePullMetrics, "foo", "controller1")
+	assert.True(t, ok)
+
+	requeue, err = r.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
+	assert.NoError(t, err)
+	assert.False(t, requeue)
 }
 
 func TestRedisCurrentlyQueuedTasksCount(t *testing.T) {
@@ -306,9 +338,24 @@ func TestRedisCurrentlyQueuedTasksCount(t *testing.T) {
 
 	count, _ := r.CurrentlyQueuedTasksCount(testCtx)
 	assert.Equal(t, uint64(3), count)
-	_ = r.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
+	_, err := r.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
+	assert.NoError(t, err)
 	count, _ = r.CurrentlyQueuedTasksCount(testCtx)
 	assert.Equal(t, uint64(2), count)
+}
+
+// TestRedisCurrentlyQueuedTasksCountIgnoresDirtyMarkers ensures the dirty-task
+// bookkeeping keys introduced alongside QueueTask/UnqueueTask are not picked up
+// by the `task:*` SCAN used to report currently queued tasks.
+func TestRedisCurrentlyQueuedTasksCountIgnoresDirtyMarkers(t *testing.T) {
+	_, r := newTestRedisStore(t)
+
+	_, _ = r.QueueTask(testCtx, schemas.TaskTypePullMetrics, "foo", "controller1")
+	_, _ = r.(*Redis).SetKeepalive(testCtx, "controller1", time.Minute)
+	_, _ = r.QueueTask(testCtx, schemas.TaskTypePullMetrics, "foo", "controller1")
+
+	count, _ := r.CurrentlyQueuedTasksCount(testCtx)
+	assert.Equal(t, uint64(1), count)
 }
 
 func TestRedisExecutedTasksCount(t *testing.T) {
@@ -316,8 +363,8 @@ func TestRedisExecutedTasksCount(t *testing.T) {
 
 	_, _ = r.QueueTask(testCtx, schemas.TaskTypePullMetrics, "foo", "")
 	_, _ = r.QueueTask(testCtx, schemas.TaskTypePullMetrics, "bar", "")
-	_ = r.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
-	_ = r.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
+	_, _ = r.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
+	_, _ = r.UnqueueTask(testCtx, schemas.TaskTypePullMetrics, "foo")
 
 	count, _ := r.ExecutedTasksCount(testCtx)
 	assert.Equal(t, uint64(1), count)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -46,9 +46,12 @@ type Store interface {
 	PipelineVariablesExists(ctx context.Context, pipeline schemas.Pipeline) (bool, error)
 
 	// Helpers to keep track of currently queued tasks and avoid scheduling them
-	// twice at the risk of ending up with loads of dangling goroutines being locked
+	// twice at the risk of ending up with loads of dangling goroutines being locked.
+	// If QueueTask is called while a task is already queued/running, it marks it
+	// dirty; UnqueueTask then reports whether it should be rescheduled because
+	// its inputs may have changed since the in-flight execution started.
 	QueueTask(ctx context.Context, tt schemas.TaskType, taskUUID string, processUUID string) (bool, error)
-	UnqueueTask(ctx context.Context, tt schemas.TaskType, processUUID string) error
+	UnqueueTask(ctx context.Context, tt schemas.TaskType, taskUUID string) (requeue bool, err error)
 	CurrentlyQueuedTasksCount(ctx context.Context) (uint64, error)
 	ExecutedTasksCount(ctx context.Context) (uint64, error)
 


### PR DESCRIPTION
A pipeline/job webhook schedules a PullRefMetrics task keyed by the ref (deployment webhooks likewise key PullEnvironmentMetrics by the environment). If a second webhook for the same ref/environment arrives while the first pull is still running, ScheduleTask's dedup lock silently drops it -- GitLab still sees a 200, but nothing schedules a follow-up pull.

In the narrow window where a 'running' pipeline webhook is being processed when the terminal 'success'/'failed' webhook arrives, this leaves the ref's status metric stuck on 'running' forever, since nothing else will trigger another pull for it once the in-flight one completes.

Store.QueueTask now marks a task dirty instead of just refusing to requeue it when the lock is already held by a live process, and Store.UnqueueTask reports whether the task was marked dirty while running. The two webhook-driven task handlers (TaskHandlerPullRefMetrics, TaskHandlerPullEnvironmentMetrics) reschedule themselves when that happens, coalescing the missed event into a follow-up pull instead of losing it.

Also downgrade the existing queue-buffer-exhausted log line from Warn to Error, since it is a silent, permanent data loss (see gitlab.maximum_jobs_queue_size), not a transient condition.